### PR TITLE
Payment Account Reference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ package-lock\.json
 src/OpenApiGenerator/bin/*
 
 src/OpenApiGenerator/obj/*
+.DS_Store

--- a/spec/components/schemas/Payments/PaymentResponseCardSource.yaml
+++ b/spec/components/schemas/Payments/PaymentResponseCardSource.yaml
@@ -85,3 +85,7 @@ allOf:
         type: string
         description: The CVV check result
         example: Y
+      payment_account_reference:
+        type: string
+        description: A unique reference to the underlying card for network tokens e.g. Apple Pay/Google Pay
+        example: "EUNIX9AX7THOOJIEJ2AP6OOFAHGH4"


### PR DESCRIPTION
This PR adds `payment_account_reference` (PAR) to both request payment and get payment responses for card sources.