### PR TITLE
Renamed cavv to cryptogram

### DIFF
--- a/spec/components/schemas/Payments/3dsData.yaml
+++ b/spec/components/schemas/Payments/3dsData.yaml
@@ -29,7 +29,7 @@ properties:
     type: string
     description: Defines the E-Commerce Indicator security level associated with the payment
     example: "01"
-  cavv:
+  cryptogram:
     type: string
     description: Cryptographic identifier used by the card schemes to validate the integrity of the 3D secure payment data
     example: hv8mUFzPzRZoCAAAAAEQBDMAAAA=


### PR DESCRIPTION
As part of our realignment of terminology, CAVV (Visa specific) has been renamed to Cryptogram.