### PR TITLE
Support for external MPI

### DIFF
--- a/spec/components/schemas/Payments/3dsData.yaml
+++ b/spec/components/schemas/Payments/3dsData.yaml
@@ -25,10 +25,6 @@ properties:
         * `A` - An authentication attempt occurred but could not be completed
         * `U` - Unable to perform authentication
     example: Y
-  eci:
-    type: string
-    description: Defines the Electronic Commerce Indicator security level associated with the payment
-    example: "01"
   cryptogram:
     type: string
     description: Cryptographic identifier used by the card schemes to validate the integrity of the 3D secure payment data

--- a/spec/components/schemas/Payments/3dsRequest.yaml
+++ b/spec/components/schemas/Payments/3dsRequest.yaml
@@ -1,0 +1,24 @@
+type: object
+description: Information required for 3D-Secure payments
+properties:
+  enabled:
+    type: boolean
+    description: Whether to process this payment as a 3D-Secure
+    default: false
+    example: true
+  attempt_n3d:
+    type: boolean
+    description: |
+      Determines whether to attempt a 3D-Secure payment as non-3DS
+      should the card issuer not be enrolled.
+      [Read more](https://docs.checkout.com/getting-started/merchant-api/3d-secure-charges/attempt-non-3d-secure-charge).
+    default: false
+    example: true
+  eci:
+    type: string
+    description: The Electronic Commerce Indicator security level associated with the token or 3D-Secure enrollment result
+    example: "05"
+  cryptogram:
+    type: string
+    description: Cryptographic identifier used by the card schemes to validate the cardholder authentication result (3D-Secure)
+    example: AgAAAAAAAIR8CQrXcIhbQAAAAAA=

--- a/spec/components/schemas/Payments/3dsRequest.yaml
+++ b/spec/components/schemas/Payments/3dsRequest.yaml
@@ -16,9 +16,13 @@ properties:
     example: true
   eci:
     type: string
-    description: The Electronic Commerce Indicator security level associated with the token or 3D-Secure enrollment result
+    description: The Electronic Commerce Indicator security level associated with the 3D-Secure enrollment result
     example: "05"
   cryptogram:
     type: string
     description: Cryptographic identifier used by the card schemes to validate the cardholder authentication result (3D-Secure)
     example: AgAAAAAAAIR8CQrXcIhbQAAAAAA=
+  xid:
+    type: string
+    description: The 3D-Secure transaction identifier
+    example: MDAwMDAwMDAwMDAwMDAwMzIyNzY=

--- a/spec/components/schemas/Payments/PaymentRequest.yaml
+++ b/spec/components/schemas/Payments/PaymentRequest.yaml
@@ -82,18 +82,7 @@ properties:
         allOf:
           - $ref: '#/components/schemas/PhoneNumber'
   3ds:
-    type: boolean
-    description: Whether to process this payment as a 3D-Secure
-    default: false
-    example: true
-  attempt_n3d:
-    type: boolean
-    description: |
-      Determines whether to attempt a 3D-Secure payment as non-3DS
-      should the card issuer not be enrolled.
-      [Read more](https://docs.checkout.com/getting-started/merchant-api/3d-secure-charges/attempt-non-3d-secure-charge).
-    default: false
-    example: true
+    $ref: '#/components/schemas/3dsRequest'
   previous_payment_id:
     type: string
     description: |

--- a/spec/components/schemas/Payments/PaymentRequestNetworkTokenSource.yaml
+++ b/spec/components/schemas/Payments/PaymentRequestNetworkTokenSource.yaml
@@ -10,6 +10,7 @@ allOf:
       - expiry_year
       - eci
       - token_cryptogram
+      - token_type
     properties:
       type:
         type: string
@@ -37,10 +38,6 @@ allOf:
         type: string
         description: Cryptographic identifier used by card schemes to validate the token verification result
         example: hv8mUFzPzRZoCAAAAAEQBDMAAAA=
-      cryptogram:
-        type: string
-        description: Cryptographic identifier used by the card schemes to validate the cardholder authentication result (3D-Secure)
-        example: AgAAAAAAAIR8CQrXcIhbQAAAAAA=
       name:
         type: string
         description: The cardholder name
@@ -51,6 +48,13 @@ allOf:
         example: "956"
         minLength: 3
         maxLength: 4
+      token_type:
+        type: string
+        description: The type of token 
+        enum:
+          - vts
+          - applepay
+          - googlepay 
       billing_address:
         description: The cardholder's billing address
         allOf:

--- a/spec/components/schemas/Payments/PaymentRequestNetworkTokenSource.yaml
+++ b/spec/components/schemas/Payments/PaymentRequestNetworkTokenSource.yaml
@@ -8,8 +8,6 @@ allOf:
       - token
       - expiry_month
       - expiry_year
-      - eci
-      - token_cryptogram
       - token_type
     properties:
       type:
@@ -30,14 +28,24 @@ allOf:
         type: integer
         description: The four-digit expiry year of the token
         example: 2025
-      eci:
+      token_type:
         type: string
-        description: The Electronic Commerce Indicator security level associated with the token or 3D-Secure enrollment result
-        example: "05"
+        description: The type of token 
+        enum:
+          - vts
+          - applepay
+          - googlepay 
       token_cryptogram:
         type: string
-        description: Cryptographic identifier used by card schemes to validate the token verification result
+        description: Cryptographic identifier used by card schemes to validate the token verification result. Required unless the `previous_payment_id` is specified.
         example: hv8mUFzPzRZoCAAAAAEQBDMAAAA=
+      eci:
+        type: string
+        description: | 
+          The Electronic Commerce Indicator security level associated with the token. 
+          Required unless the `previous_payment_id` is specified.
+          For 3D-Secure payments the ECI must be provided in the `3ds` payment field.
+        example: "05"
       name:
         type: string
         description: The cardholder name
@@ -48,13 +56,6 @@ allOf:
         example: "956"
         minLength: 3
         maxLength: 4
-      token_type:
-        type: string
-        description: The type of token 
-        enum:
-          - vts
-          - applepay
-          - googlepay 
       billing_address:
         description: The cardholder's billing address
         allOf:


### PR DESCRIPTION
This PR adds support for both external MPIs and processing of pre-decrypted Apple Pay PANs. We've also standardised the returning of ECI following the introduction of the `network_token` source type.