### PR TITLE
Idempotency Keys

### DIFF
--- a/spec/paths/payments.yaml
+++ b/spec/paths/payments.yaml
@@ -142,8 +142,8 @@ post:
             $ref: "#/components/headers/Cko-Version"
     '401':
       description: Unauthorized
-    '409':
-      description: Conflict or duplicate request detected
+    '429':
+      description: Too many requests or duplicate request detected
       content:
         application/json:
           schema:

--- a/spec/paths/payments.yaml
+++ b/spec/paths/payments.yaml
@@ -142,6 +142,12 @@ post:
             $ref: "#/components/headers/Cko-Version"
     '401':
       description: Unauthorized
+    '409':
+      description: Conflict or duplicate request detected
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ValidationError'
     '422':
       description: Invalid data was sent
       content:

--- a/spec/paths/payments.yaml
+++ b/spec/paths/payments.yaml
@@ -100,6 +100,14 @@ post:
     }
     ```
 
+  parameters:
+    - in: header
+      name: Cko-Idempotency-Key
+      schema:
+        type: string
+      required: false
+      description: Optional idempotency key for safely retrying payment requests
+
   requestBody:
     content:
       application/json:


### PR DESCRIPTION
This PR adds the `Cko-Idempotency-Key` header definition to the `/payments` endpoint to support safe retries of payment requests.

https://api-reference.checkout.com/preview/task/gw-1434-idempotency-key/#tag/Payments/paths/~1payments/post