### PR TITLE
Added c# payment examples

### DIFF
--- a/spec/code_samples/C#/payments/post.cs
+++ b/spec/code_samples/C#/payments/post.cs
@@ -1,3 +1,4 @@
+var api = CheckoutApi.Create("your secret key");
 var tokenSource = new TokenSource("tok_ubfj2q76miwundwlk72vxt2i7q");
 var paymentRequest = new PaymentRequest<TokenSource>(tokenSource, Currency.USD, 5600)
 {
@@ -8,7 +9,7 @@ var paymentRequest = new PaymentRequest<TokenSource>(tokenSource, Currency.USD, 
 
 try
 {
-    var response = await Api.Payments.RequestAsync(paymentRequest);
+    var response = await api.Payments.RequestAsync(paymentRequest);
 
     if (response.IsPending && response.Pending.RequiresRedirect())
     {

--- a/spec/code_samples/C#/payments@{id}/get.cs
+++ b/spec/code_samples/C#/payments@{id}/get.cs
@@ -1,0 +1,8 @@
+var api = CheckoutApi.Create("your secret key");
+var threeDsSessionId = "sid_y3oqhf46pyzuxjbcn2giaqnb44";
+var payment = await api.Payments.GetAsync(threeDsSessionId);
+
+if (payment.Approved)
+{            
+    var cardSourceId = payment.Source.AsCard().Id;
+}

--- a/spec/code_samples/C#/payments@{id}@captures/post.cs
+++ b/spec/code_samples/C#/payments@{id}@captures/post.cs
@@ -1,0 +1,14 @@
+var api = CheckoutApi.Create("your secret key");
+var paymentId = "pay_y3oqhf46pyzuxjbcn2giaqnb44";
+
+// Full capture
+await _api.Payments.CaptureAsync(paymentId);
+
+// Or partial capture
+var captureRequest = new CaptureRequest
+{
+    Reference = "your reference",
+    Amount = 100
+};
+
+await _api.Payments.CaptureAsync(paymentId, captureRequest);

--- a/spec/code_samples/C#/payments@{id}@refunds/post.cs
+++ b/spec/code_samples/C#/payments@{id}@refunds/post.cs
@@ -1,0 +1,14 @@
+var api = CheckoutApi.Create("your secret key");
+var paymentId = "pay_y3oqhf46pyzuxjbcn2giaqnb44";
+
+// Full refund
+await _api.Payments.RefundAsync(paymentId);
+
+// Or partial refund
+var refundRequest = new RefundRequest
+{
+    Reference = "your reference",
+    Amount = 100
+};
+
+await _api.Payments.RefundAsync(paymentId, refundRequest);

--- a/spec/code_samples/C#/payments@{id}@voids/post.cs
+++ b/spec/code_samples/C#/payments@{id}@voids/post.cs
@@ -1,0 +1,4 @@
+var api = CheckoutApi.Create("your secret key");
+var paymentId = "pay_y3oqhf46pyzuxjbcn2giaqnb44";
+
+await _api.Payments.VoidAsync(paymentId);


### PR DESCRIPTION
This PR adds C# examples using the new Checkout.com SDK for .NET - https://github.com/checkout/checkout-sdk-net.

