### PR TITLE
Include summary of actions in get payment response

### DIFF
--- a/spec/components/schemas/Payments/Payment.yaml
+++ b/spec/components/schemas/Payments/Payment.yaml
@@ -142,7 +142,7 @@ properties:
     items:
       $ref: '#/components/schemas/PaymentActionSummary'
     description: |
-      A summary of the payment actions, 
+      A summary of the payment's actions, 
       returned when a session ID is used to get the payment details
   _links:
     type: object

--- a/spec/components/schemas/Payments/Payment.yaml
+++ b/spec/components/schemas/Payments/Payment.yaml
@@ -137,6 +137,13 @@ properties:
     description: |
       The scheme transaction identifier
     example: "488341541494658"
+  actions:
+    type: array
+    items:
+      $ref: '#/components/schemas/PaymentActionSummary'
+    description: |
+      A summary of the payment actions, 
+      returned when a session ID is used to get the payment details
   _links:
     type: object
     description: The links related to the payment

--- a/spec/components/schemas/Payments/PaymentActionSummary.yaml
+++ b/spec/components/schemas/Payments/PaymentActionSummary.yaml
@@ -1,0 +1,28 @@
+type: object
+required:
+  - id
+  - type
+  - response_code
+properties:
+  id:
+    description: The unique identifier of the payment action
+    allOf:
+      - $ref: '#/components/schemas/ActionId'
+  type:
+    type: string
+    description: The type of action
+    enum:
+      - Authorization
+      - Card Verification
+      - Void
+      - Capture
+      - Refund
+  response_code:
+    type: string
+    description: Gateway response code
+    example: "10000"
+  response_summary:
+    type: string
+    description: The Gateway response summary
+    example: "Approved"
+


### PR DESCRIPTION
This PR presents the proposal to embed a summary of payment actions in the payment actions response for redirect payment methods, when using a session identifier.

https://api-reference.checkout.com/preview/feature/embed-payment-actions

**Do not merge until 3.25.0 of the Gateway API is release.**