### PR TITLE
Updated cryptogram descriptions to include encoding format

### DIFF
--- a/spec/components/schemas/Payments/3dsData.yaml
+++ b/spec/components/schemas/Payments/3dsData.yaml
@@ -27,7 +27,7 @@ properties:
     example: Y
   cryptogram:
     type: string
-    description: Cryptographic identifier used by the card schemes to validate the integrity of the 3-D secure payment data
+    description: Base64 encoded cryptographic identifier (CAVV) used by the card schemes to validate the integrity of the 3-D secure payment data
     example: hv8mUFzPzRZoCAAAAAEQBDMAAAA=
   xid:
     type: string

--- a/spec/components/schemas/Payments/3dsRequest.yaml
+++ b/spec/components/schemas/Payments/3dsRequest.yaml
@@ -20,7 +20,7 @@ properties:
     example: "05"
   cryptogram:
     type: string
-    description: Cryptographic identifier used by the card schemes to validate the cardholder authentication result (3-D Secure). Required if using an external MPI.
+    description: Base64 encoded cryptographic identifier (CAVV) used by the card schemes to validate the cardholder authentication result (3-D Secure). Required if using an external MPI.
     example: AgAAAAAAAIR8CQrXcIhbQAAAAAA=
   xid:
     type: string

--- a/spec/components/schemas/Payments/RequestSources/05_PaymentRequestNetworkTokenSource.yaml
+++ b/spec/components/schemas/Payments/RequestSources/05_PaymentRequestNetworkTokenSource.yaml
@@ -32,7 +32,7 @@ allOf:
           - googlepay 
       cryptogram:
         type: string
-        description: Cryptographic identifier used by card schemes to validate the token verification result. Required unless the `previous_payment_id` is specified.
+        description: Base64 encoded cryptographic identifier (TAVV) used by card schemes to validate the token verification result. Required unless the `previous_payment_id` is specified.
         example: hv8mUFzPzRZoCAAAAAEQBDMAAAA=
       eci:
         type: string


### PR DESCRIPTION
This PR updates the descriptions for network token and 3-D Secure cryptograms to specify the expected encoding format (Base64).

It also includes the schema specific terminology that merchants may be more familiar with.