### PR TITLE
Task/add wechat unionpay specs

### DIFF
--- a/scripts/sync-generated-specs.js
+++ b/scripts/sync-generated-specs.js
@@ -15,8 +15,14 @@ var syncPaymentSources = function()
   syncPaymentResponse('Ideal', 'http://sb-gateway-internal.cko.lon/ideal-internal-api/relations/gw/payment', '05');
   syncPaymentRequest('Klarna', 'http://sb-gateway-internal.cko.lon/klarna-internal/relations/gw/pay', '10');
   syncPaymentResponse('Klarna', 'http://sb-gateway-internal.cko.lon/klarna-internal/relations/gw/payment', '06');
-  syncPaymentResponse('Bancontact', 'http://sb-gateway-internal.cko.lon/ppro-internal/bancontact/relations/gw/pay', '15');
+  syncPaymentRequest('Bancontact', 'http://sb-gateway-internal.cko.lon/ppro-internal/bancontact/relations/gw/pay', '15');
   syncPaymentResponse('Bancontact', 'http://sb-gateway-internal.cko.lon/ppro-internal/bancontact/relations/gw/payment', '15');
+  syncPaymentRequest('WeChat QR', 'http://sb-gateway-internal.cko.lon/fomo-internal/wechat-qr/relations/gw/pay', '16');
+  syncPaymentResponse('WeChat QR', 'http://sb-gateway-internal.cko.lon/fomo-internal/wechat-qr/relations/gw/payment', '16');
+  syncPaymentRequest('WeChat Web', 'http://sb-gateway-internal.cko.lon/fomo-internal/wechat-web/relations/gw/pay', '17');
+  syncPaymentResponse('WeChat Web', 'http://sb-gateway-internal.cko.lon/fomo-internal/wechat-web/relations/gw/payment', '17');
+  syncPaymentRequest('Unionpay', 'http://sb-gateway-internal.cko.lon/fomo-internal/unionpay/relations/gw/pay', '18');
+  syncPaymentResponse('Unionpay', 'http://sb-gateway-internal.cko.lon/fomo-internal/unionpay/relations/gw/payment', '18');
 }
 
 var syncPaymentRequest = function(paymentSourceName, paymentSpecUrl, outputFilePrefix) {
@@ -77,7 +83,9 @@ var getFunctionToBuildPaymentResponse = function(paymentSourceName) {
   return function(responseBody) {
     var properties = responseBody.get.responses[200].content['application/json'].schema.properties;
     var responseDataProperties = null;
-    if (properties) {
+
+    //Some APMS don't set response_data if they don't have any. (e.g. fomo)
+    if (properties && properties.response_data) {
       responseDataProperties = properties.response_data.properties;
       if (responseDataProperties && responseDataProperties.type) {
         delete responseDataProperties.type;

--- a/spec/components/schemas/Payments/PaymentRequestSource.yaml
+++ b/spec/components/schemas/Payments/PaymentRequestSource.yaml
@@ -18,6 +18,9 @@ discriminator:
     safetypay: '#/components/schemas/13_PaymentRequestSafetyPaySource'
     sofort: '#/components/schemas/14_PaymentRequestSofortSource'
     bancontact: '#/components/schemas/15_PaymentRequestBancontactSource'
+    wechat-qr: '#/components/schemas/16_PaymentRequestWeChat QRSource'
+    wechat-web: '#/components/schemas/17_PaymentRequestWeChat WebSource'
+    unionpay: '#/components/schemas/18_PaymentRequestUnionpaySource'
 required:
   - type
 properties:

--- a/spec/components/schemas/Payments/PaymentResponseSource.yaml
+++ b/spec/components/schemas/Payments/PaymentResponseSource.yaml
@@ -15,6 +15,9 @@ discriminator:
     safetypay: '#/components/schemas/09_PaymentResponseSafetyPaySource'
     sofort: '#/components/schemas/10_PaymentResponseSofortSource'
     bancontact: '#/components/schemas/15_PaymentResponseBancontactSource'
+    wechat-qr: '#/components/schemas/16_PaymentResponseWeChat QRSource'
+    wechat-web: '#/components/schemas/17_PaymentResponseWeChat WebSource'
+    unionpay: '#/components/schemas/18_PaymentResponseUnionpaySource'
 required:
   - type
 

--- a/spec/components/schemas/Payments/RequestSources/10_PaymentRequestKlarnaSource.yaml
+++ b/spec/components/schemas/Payments/RequestSources/10_PaymentRequestKlarnaSource.yaml
@@ -32,12 +32,10 @@ allOf:
         description: 'Allow merchant to trigger auto capturing.'
         x-klarna-docs: 'https://developers.klarna.com/api/#payments-api__create-a-new-order__auto_capture'
       billing_address:
-        type: object
         description: "Customer's billing address.  \nThis object is passed directly to Klarna as `billing_address`, \nso for the object definition use the [Klarna documentation](https://developers.klarna.com/api/#payments-api__create-a-new-order__billing_address)."
         x-klarna-docs: 'https://developers.klarna.com/api/#payments-api__create-a-new-order__billing_address'
         x-cko-passthrough: true
       shipping_address:
-        type: object
         description: "Customer's shipping address.  \nThis object is passed directly to Klarna as `shipping_address`, \nso for the object definition use the [Klarna documentation](https://developers.klarna.com/api/#payments-api__create-a-new-order__shipping_address)."
         x-klarna-docs: 'https://developers.klarna.com/api/#payments-api__create-a-new-order__shipping_address'
         x-cko-passthrough: true
@@ -47,7 +45,7 @@ allOf:
         x-klarna-name: order_tax_amount
         x-klarna-docs: 'https://developers.klarna.com/api/#payments-api__create-a-new-order__order_tax_amount'
       products:
-        type: array
+        type: object
         description: "The applicable order lines.  \nThis object is passed directly to Klarna as `order_lines`, \nso for the object definition use the [Klarna documentation](https://developers.klarna.com/api/#payments-api__create-a-new-order__order_lines)."
         x-klarna-name: order_lines
         x-cko-passthrough: true
@@ -59,11 +57,11 @@ allOf:
         x-cko-passthrough: true
       merchant_reference1:
         type: string
-        description: 'Used for storing merchant''s internal order number or other reference.  If set, will be shown on the confirmation page as "order number" (max 255 characters).'
+        description: 'Used for storing merchant''s internal order number or other reference.  If set, will be shown on the confirmation page as "order number"  (max 255 characters).'
         x-klarna-docs: 'https://developers.klarna.com/api/#payments-api__create-a-new-order__merchant_reference1'
       merchant_reference2:
         type: string
-        description: 'Used for storing merchant''s internal order number or other reference (max 255 characters).'
+        description: 'Used for storing merchant''s internal order number or other reference  (max 255 characters).'
         x-klarna-docs: 'https://developers.klarna.com/api/#payments-api__create-a-new-order__merchant_reference2'
       merchant_data:
         type: string

--- a/spec/components/schemas/Payments/RequestSources/16_PaymentRequestWeChat QRSource.yaml
+++ b/spec/components/schemas/Payments/RequestSources/16_PaymentRequestWeChat QRSource.yaml
@@ -1,0 +1,17 @@
+###
+# Warning: this file was auto generated from OpenAPI specs using 'npm run sync-generated-specs'. Do not manually edit. 
+###
+type: object
+description: 'WeChat QR Source'
+allOf:
+  -
+    $ref: '#/components/schemas/PaymentRequestSource'
+  -
+    type: object
+    required:
+      - description
+    properties:
+      description:
+        maxLength: 65534
+        type: string
+        description: 'Payment description'

--- a/spec/components/schemas/Payments/RequestSources/17_PaymentRequestWeChat WebSource.yaml
+++ b/spec/components/schemas/Payments/RequestSources/17_PaymentRequestWeChat WebSource.yaml
@@ -1,0 +1,17 @@
+###
+# Warning: this file was auto generated from OpenAPI specs using 'npm run sync-generated-specs'. Do not manually edit. 
+###
+type: object
+description: 'WeChat Web Source'
+allOf:
+  -
+    $ref: '#/components/schemas/PaymentRequestSource'
+  -
+    type: object
+    required:
+      - description
+    properties:
+      description:
+        maxLength: 65534
+        type: string
+        description: 'Payment description'

--- a/spec/components/schemas/Payments/RequestSources/18_PaymentRequestUnionpaySource.yaml
+++ b/spec/components/schemas/Payments/RequestSources/18_PaymentRequestUnionpaySource.yaml
@@ -1,0 +1,17 @@
+###
+# Warning: this file was auto generated from OpenAPI specs using 'npm run sync-generated-specs'. Do not manually edit. 
+###
+type: object
+description: 'Unionpay Source'
+allOf:
+  -
+    $ref: '#/components/schemas/PaymentRequestSource'
+  -
+    type: object
+    required:
+      - description
+    properties:
+      description:
+        maxLength: 65534
+        type: string
+        description: 'Payment description'

--- a/spec/components/schemas/Payments/ResponseSources/16_PaymentResponseWeChat QRSource.yaml
+++ b/spec/components/schemas/Payments/ResponseSources/16_PaymentResponseWeChat QRSource.yaml
@@ -1,0 +1,11 @@
+###
+# Warning: this file was auto generated from OpenAPI specs using 'npm run sync-generated-specs'. Do not manually edit. 
+###
+type: object
+description: 'WeChat QR Source'
+allOf:
+  -
+    $ref: '#/components/schemas/PaymentResponseSource'
+  -
+    type: object
+    properties: null

--- a/spec/components/schemas/Payments/ResponseSources/17_PaymentResponseWeChat WebSource.yaml
+++ b/spec/components/schemas/Payments/ResponseSources/17_PaymentResponseWeChat WebSource.yaml
@@ -1,0 +1,11 @@
+###
+# Warning: this file was auto generated from OpenAPI specs using 'npm run sync-generated-specs'. Do not manually edit. 
+###
+type: object
+description: 'WeChat Web Source'
+allOf:
+  -
+    $ref: '#/components/schemas/PaymentResponseSource'
+  -
+    type: object
+    properties: null

--- a/spec/components/schemas/Payments/ResponseSources/18_PaymentResponseUnionpaySource.yaml
+++ b/spec/components/schemas/Payments/ResponseSources/18_PaymentResponseUnionpaySource.yaml
@@ -1,0 +1,11 @@
+###
+# Warning: this file was auto generated from OpenAPI specs using 'npm run sync-generated-specs'. Do not manually edit. 
+###
+type: object
+description: 'Unionpay Source'
+allOf:
+  -
+    $ref: '#/components/schemas/PaymentResponseSource'
+  -
+    type: object
+    properties: null


### PR DESCRIPTION
Sits on top of bancontact to preserve order and to avoid merge conflicts. Once bancontact got merged this can be rebased.