### PR TITLE
Add P24 to Request- and ResponseSource list

### DIFF
--- a/spec/components/schemas/Payments/PaymentRequestSource.yaml
+++ b/spec/components/schemas/Payments/PaymentRequestSource.yaml
@@ -15,6 +15,7 @@ discriminator:
     ideal: '#/components/schemas/PaymentRequestIdealSource'
     klarna: '#/components/schemas/PaymentRequestKlarnaSource'
     knet: '#/components/schemas/PaymentRequestKnetSource'
+    p24: '#/components/schemas/PaymentRequestP24Source'
     poli: '#/components/schemas/PaymentRequestPoliSource'
     sofort: '#/components/schemas/PaymentRequestSofortSource'
     bancontact: '#/components/schemas/PaymentRequestBancontactSource'

--- a/spec/components/schemas/Payments/PaymentResponseSource.yaml
+++ b/spec/components/schemas/Payments/PaymentResponseSource.yaml
@@ -12,6 +12,7 @@ discriminator:
     ideal: '#/components/schemas/PaymentResponseIdealSource'
     klarna: '#/components/schemas/PaymentResponseKlarnaSource'
     knet: '#/components/schemas/PaymentResponseKnetSource'
+    p24: '#/components/schemas/PaymentResponseP24Source'
     poli: '#/components/schemas/PaymentResponsePoliSource'
     sofort: '#/components/schemas/PaymentResponseSofortSource'
     bancontact: '#/components/schemas/PaymentResponseBancontactSource'


### PR DESCRIPTION
Added Przelewy24 (P24) to the discriminator mapping list in the PaymentRequestSource and PaymentResponseSource files so the name of the payment method appears correctly.