### PR TITLE
Fix minor vs major currency units

### DIFF
--- a/spec/components/schemas/Payments/CaptureRequest.yaml
+++ b/spec/components/schemas/Payments/CaptureRequest.yaml
@@ -3,7 +3,7 @@ properties:
   amount:
     type: integer
     description: |
-      The amount to capture in the major currency. If not specified, the full payment amount will be captured
+      The amount to capture in the minor currency. If not specified, the full payment amount will be captured
     minimum: 0
     example: 6540
   reference:

--- a/spec/components/schemas/Payments/PaymentRequest.yaml
+++ b/spec/components/schemas/Payments/PaymentRequest.yaml
@@ -7,7 +7,7 @@ properties:
   amount:
     type: integer
     description: |
-      The payment amount in the major currency.
+      The payment amount in the minor currency.
       The exact format <a href="https://docs.checkout.com/docs/calculating-the-value" target="blank">depends on the currency</a>.
       Omit the amount or provide a value of `0` to perform a card verification. 
     minimum: 0

--- a/spec/components/schemas/Payments/Payout.yaml
+++ b/spec/components/schemas/Payments/Payout.yaml
@@ -7,7 +7,7 @@ properties:
   amount:
     type: integer
     description: |
-      The payment amount in the major currency.
+      The payment amount in the minor currency.
       The exact format <a href="https://docs.checkout.com/docs/calculating-the-value" target="blank">depends on the currency</a>.
       Omit the amount or provide a value of `0` to perform a card verification.
     minimum: 0

--- a/spec/components/schemas/Payments/RefundRequest.yaml
+++ b/spec/components/schemas/Payments/RefundRequest.yaml
@@ -3,7 +3,7 @@ properties:
   amount:
     type: integer
     description: |
-      The amount to refund in the major currency. If not specified, the full payment amount will be refunded
+      The amount to refund in the minor currency. If not specified, the full payment amount will be refunded
     minimum: 0
     example: 6540
   reference:


### PR DESCRIPTION
In a few places we have amounts which are self contradictory about whether they are passed as minor or major currency units, i.e. 
- minor unit = normally `integer` type and the example should be like 1050 (for 10.50 GBP)
- major unit = normally `number` type and the example should be like 10.50 (for 10.50 GBP)

_Preview:_ https://api-reference.checkout.com/preview/fix/currency-minor-vs-major/

**Possible extras for this PR:**

There are other 2 further places with this issue, but I'm not sure where they render on the UI. If someone knows if they are really minor or major, and where they are on the UI, I can fix them too:
- `Item.yaml` `price` (possibly previously on a payment request)
- `PaymentDestination.yaml` `amount` (possibly `OpenPay` related, based on descriptions)

Furthermore, there are many places where we don't specify if the `amount` is in minor or major currency units. These should be explicit.