### PR TITLE
Remove major currency terminology

### DIFF
--- a/spec/components/schemas/Payments/CaptureRequest.yaml
+++ b/spec/components/schemas/Payments/CaptureRequest.yaml
@@ -3,7 +3,7 @@ properties:
   amount:
     type: integer
     description: |
-      The amount to capture in the major currency. If not specified, the full payment amount will be captured
+      The amount to capture. If not specified, the full payment amount will be captured
     minimum: 0
     example: 6540
   reference:

--- a/spec/components/schemas/Payments/PaymentRequest.yaml
+++ b/spec/components/schemas/Payments/PaymentRequest.yaml
@@ -7,7 +7,7 @@ properties:
   amount:
     type: integer
     description: |
-      The payment amount in the major currency.
+      The payment amount.
       The exact format <a href="https://docs.checkout.com/docs/calculating-the-value" target="blank">depends on the currency</a>.
       Omit the amount or provide a value of `0` to perform a card verification. 
     minimum: 0

--- a/spec/components/schemas/Payments/Payout.yaml
+++ b/spec/components/schemas/Payments/Payout.yaml
@@ -7,7 +7,7 @@ properties:
   amount:
     type: integer
     description: |
-      The payment amount in the major currency.
+      The payment amount.
       The exact format <a href="https://docs.checkout.com/docs/calculating-the-value" target="blank">depends on the currency</a>.
       Omit the amount or provide a value of `0` to perform a card verification.
     minimum: 0

--- a/spec/components/schemas/Payments/RefundRequest.yaml
+++ b/spec/components/schemas/Payments/RefundRequest.yaml
@@ -3,7 +3,7 @@ properties:
   amount:
     type: integer
     description: |
-      The amount to refund in the major currency. If not specified, the full payment amount will be refunded
+      The amount to refund. If not specified, the full payment amount will be refunded
     minimum: 0
     example: 6540
   reference:


### PR DESCRIPTION
Removed the 'major currency' terminology because it's confusing.