### PR TITLE
Change to allow Quotes to be optionally reusable

### DIFF
--- a/spec/components/schemas/Forex/QuoteRequest.yaml
+++ b/spec/components/schemas/Forex/QuoteRequest.yaml
@@ -11,7 +11,6 @@ properties:
     type: integer
     description: | 
       The amount to be converted from the source currency in the minor currency unit.
-      If omitted the `destination_amount` must be provided.
 
       The amount must be provided in the <a href="https://docs.checkout.com/docs/calculating-the-value" target="blank">minor currency unit</a>.
     example: 30000
@@ -23,7 +22,6 @@ properties:
     type: integer
     description: | 
       The amount to be converted to the destination currency in the minor currency unit.
-      If omitted the `source_amount` must be provided.
 
       The amount must be provided in the <a href="https://docs.checkout.com/docs/calculating-the-value" target="blank">minor currency unit</a>.
 example:

--- a/spec/components/schemas/Forex/QuoteResponse.yaml
+++ b/spec/components/schemas/Forex/QuoteResponse.yaml
@@ -28,3 +28,7 @@ properties:
     type: string
     format: date-time
     description: The date/time that the quote expires
+  is_single_use:
+    type: boolean
+    description : If the quote is restricted to a single use, or can be confirmed multiple times before expiry
+    example: false 


### PR DESCRIPTION
**Changes**
* Don't require the source and destination amount when requesting a quote
* Add `is_single_use` flag to the response

Not requiring the source and destination amounts, as they aren't needed if we allow quote's to be reused. Not removing them, because without the amounts we can't provide better rates for high volumes.

Added the `is_single_use` flag so we can reuse quotes, but still provide single use quotes for volume pricing