### PR TITLE
Disputes Scopes + New Filters (Crusoe)

### DIFF
--- a/spec/components/schemas/Disputes/Dispute.yaml
+++ b/spec/components/schemas/Disputes/Dispute.yaml
@@ -5,6 +5,10 @@ properties:
     pattern: "^(dsp)_(\\w{22})$"
     description: The dispute identifier. This is the same as the payment action ID
     example: "dsp_rbhwd2qrg13uhrp2newf"
+  entity_id:
+    type: string
+    description: The client entity linked to this dispute
+    example: "ent_wxglze3wwywujg4nna5fb7ldli"
   category:
     type: string
     description: The reason for the dispute. [Find out more](https://docs.checkout.com/docs/disputes#section-dispute-reasons-and-recommended-evidence)
@@ -50,32 +54,9 @@ properties:
     example: "2018-08-04T10:53:13Z"
   payment:
     type: object
-    properties:
-      id:
-        type: string
-        description: The payment identifier
-        example: "pay_88cb4e671m1da22e9bbbyx"
-      amount:
-        type: number
-        description: The amount that is being disputed, in the processing currency
-        example: 999
-      currency:
-        type: string
-        description: The payment currency
-        example: "GBP"
-      method:
-        type: string
-        description: The payment method used
-        example: "Visa"
-      arn:
-        type: string
-        description: The acquirer reference number (ARN)
-        example: "AA246873253573571073808"
-      processed_on:
-        type: string
-        format: ISO-8601
-        description: The date and time at which the payment was requested
-        example: "2018-08-01T08:18:10Z"
+    description: Provides details for the payment linked to the dispute
+    allOf:
+      - $ref: '#/components/schemas/PaymentData'
   _links:
     type: object
     properties:
@@ -85,7 +66,7 @@ properties:
           href:
             example: "https://api.checkout.com/disputes/dsp_rbhwd2qrg13uhrp2newf"
       evidence:
-        description: The dispute evidence retrieval endopint
+        description: The dispute evidence retrieval endpoint
         properties:    
           href:
             example: "https://api.checkout.com/disputes/dsp_rbhwd2qrg13uhrp2newf/evidence"

--- a/spec/components/schemas/Disputes/Dispute.yaml
+++ b/spec/components/schemas/Disputes/Dispute.yaml
@@ -29,7 +29,7 @@ properties:
   status:
     type: string
     description: The current status of the dispute
-    enum: [evidence_required, evidence_under_review, resolved, won, lost, canceled, expired, accepted]
+    enum: [evidence_required, evidence_under_review, resolved, won, lost, canceled, expired, accepted, arbitration_under_review, arbitration_won, arbitration_lost]
     example: "evidence_required"
   relevant_evidence:
     type: array

--- a/spec/components/schemas/Disputes/DisputePaged.yaml
+++ b/spec/components/schemas/Disputes/DisputePaged.yaml
@@ -18,15 +18,19 @@ properties:
     format: ISO-8601
     description: The date and time until which to filter disputes, based on the dispute's `last_update` field
     example: "2018-08-13T11:09:01Z"
-  statuses:
-    type: string
-    description: One or more comma-separated statuses. This works like a logical *OR* operator
-    example: "evidence_required,evidence_under_review"
   id:
     type: string
     pattern: "^(dsp)_(\\w{22})$"
     description: The unique identifier of the dispute
     example: "dsp_rbhwd2qrg13uhrp2newf"
+  entity_ids:
+    type: string
+    description: One or more comma-separated client entities. This works like a logical *OR* operator
+    example: "ent_wxglze3wwywujg4nna5fb7ldli,ent_vkb5zcy64zoe3cwfmaqvqyqyku"
+  statuses:
+    type: string
+    description: One or more comma-separated statuses. This works like a logical *OR* operator
+    example: "evidence_required,evidence_under_review"
   payment_id:
     type: string
     pattern: "^(pay)_(\\w{26})$"
@@ -40,6 +44,10 @@ properties:
     type: string
     description: The acquirer reference number (ARN) that you can use to query the issuing bank
     example: "74548998294293193445538"
+  payment_mcc:
+    type: string
+    description: The merchant category code (MCC) of the payment (ISO 18245)
+    example: "5021"
   this_channel_only:
     type: boolean
     description: If `true`, only returns disputes of the specific channel that the secret key is associated with. Otherwise, returns all disputes for that business

--- a/spec/components/schemas/Disputes/DisputeSummary.yaml
+++ b/spec/components/schemas/Disputes/DisputeSummary.yaml
@@ -17,7 +17,7 @@ properties:
   status:
     type: string
     description: The current status of the dispute
-    enum: [received, evidence_required, evidence_under_review, resolved, closed, won, lost, canceled, accepted]
+    enum: [evidence_required, evidence_under_review, resolved, won, lost, canceled, expired, accepted, arbitration_under_review, arbitration_won, arbitration_lost]
     example: "evidence_required"
   amount:
     type: number

--- a/spec/components/schemas/Disputes/DisputeSummary.yaml
+++ b/spec/components/schemas/Disputes/DisputeSummary.yaml
@@ -5,6 +5,10 @@ properties:
     pattern: "^(dsp)_(\\w{22})$"
     description: The dispute identifier. This is the same as the action ID in the reconciliation API or the charge ID in the Hub.
     example: "dsp_rbhwd2qrg13uhrp2newf"
+  entity_id:
+    type: string
+    description: The client entity linked to this dispute
+    example: "ent_wxglze3wwywujg4nna5fb7ldli"
   category:
     type: string
     description: The reason for the dispute. [Find out more](https://docs.checkout.com/docs/disputes#section-dispute-reasons-and-recommended-evidence)
@@ -27,6 +31,10 @@ properties:
     type: string
     description: The unique payment identifier
     example: "pay_88cb4e671m1da22e9bbbyx"
+  payment_action_id:
+    type: string
+    description: The unique identifier of the payment action
+    example: "act_mbabizu24mvu3mela5njyhpit4"
   payment_reference:
     type: string
     description: An optional reference (such as an order ID) a merchant can use to later identify the charge. Previously known as TrackId
@@ -35,6 +43,10 @@ properties:
     type: string
     description: The acquirer reference number that can be used to query the issuing bank
     example: "74548998294293193445538"
+  payment_mcc:
+    type: string
+    description: The merchant category code (MCC) of the payment (ISO 18245)
+    example: "5021"
   payment_method:
     type: string
     description: The payment method/card scheme

--- a/spec/components/schemas/Disputes/PaymentData.yaml
+++ b/spec/components/schemas/Disputes/PaymentData.yaml
@@ -1,0 +1,64 @@
+type: object
+properties:
+  id:
+    type: string
+    description: The payment's unique identifier
+    example: "pay_mbabizu24mvu3mela5njyhpit4"
+  action_id:
+    type: string
+    description: The unique identifier of the payment action
+    example: "act_mbabizu24mvu3mela5njyhpit4"
+  processing_channel_id:
+    type: string
+    description: The processing channel used for the payment
+    example: "mer_q4dbxom5jbgudnjzjpz7j2z6uq"
+  amount:
+    type: number
+    description: The amount that is being disputed, in the processing currency
+    example: 999
+  currency:
+    type: string
+    description: The payment currency
+    example: "GBP"
+  method:
+    type: string
+    description: The payment method used
+    example: "Visa"
+  arn:
+    type: string
+    description: The acquirer reference number (ARN)
+    example: "AA246873253573571073808"
+  mcc:
+    type: string
+    description: The merchant category code (MCC) for the payment (ISO 18245)
+    example: "5021"
+  3ds:
+    type: object
+    description: Provides information relating to the processing of 3D Secure payments
+    properties:
+      enrolled:
+        type: string
+        description: >
+          Indicates the 3D Secure enrollment status of the issuer
+            * `Y` - Issuer enrolled
+            * `N` - Customer not enrolled
+            * `U` - Unknown
+        example: Y
+      version:
+        type: string
+        description: Indicates the version of 3D Secure that was used for authentication
+        example: "2.1.0"
+  eci:
+    type: string
+    description: |
+      The final Electronic Commerce Indicator (ECI) security level used to authorize the payment. 
+      Applicable for 3D Secure, digital wallets, and network token payments
+    example: "06"
+  has_refund:
+    type: boolean
+    description: Indicates if there is any refund against the payment
+  processed_on:
+    type: string
+    format: ISO-8601
+    description: The date and time at which the payment was requested
+    example: "2018-08-01T08:18:10Z" 

--- a/spec/components/securitySchemes/OAuth.yaml
+++ b/spec/components/securitySchemes/OAuth.yaml
@@ -50,3 +50,7 @@ flows:
       "gateway:payment-captures": Capture payments
       "gateway:payment-refunds": Refund payments
       fx: Foreign exchange services
+      disputes: Access to all Disputes resources
+      "disputes:view": View disputes
+      "disputes:provide-evidence": Provide dispute evidence
+      "disputes:accept": Accept disputes

--- a/spec/paths/disputes.yaml
+++ b/spec/paths/disputes.yaml
@@ -1,15 +1,21 @@
 get:
   tags:
     - Disputes
+  security: 
+    - OAuth: 
+      - disputes
+      - disputes:view
+    - ApiKey: []
   summary: Get disputes
-  description:
-    Returns a list of all disputes against your business. The results will be returned in reverse chronological order, 
-    showing the last modified dispute (for example, where you've recently added a piece of evidence) first.
-    You can use the optional parameters below to skip or limit results.
+  description: >-
+    Returns a list of all disputes against your business. The results will be
+    returned in reverse chronological order, showing the last modified dispute
+    (for example, where you've recently added a piece of evidence) first. You
+    can use the optional parameters below to skip or limit results.
   parameters:
     - in: query
       name: limit
-      schema: 
+      schema:
         type: integer
         minimum: 1
         maximum: 250
@@ -30,14 +36,18 @@ get:
         type: string
         format: ISO-8601
       required: false
-      description: The date and time from which to filter disputes, based on the dispute's `last_update` field
+      description: >-
+        The date and time from which to filter disputes, based on the dispute's
+        `last_update` field
     - in: query
       name: to
       schema:
         type: string
         format: ISO-8601
       required: false
-      description: The date and time until which to filter disputes, based on the dispute's `last_update` field
+      description: >-
+        The date and time until which to filter disputes, based on the dispute's
+        `last_update` field
     - in: query
       name: id
       schema:
@@ -45,12 +55,23 @@ get:
       required: false
       description: The unique identifier of the dispute
     - in: query
+      name: entity_ids
+      schema:
+        type: string
+        example: 'ent_wxglze3wwywujg4nna5fb7ldli,ent_vkb5zcy64zoe3cwfmaqvqyqyku'
+      required: false
+      description: >-
+        One or more comma-separated client entities. This works like a logical *OR*
+        operator
+    - in: query
       name: statuses
       schema:
         type: string
-        example: evidence_required,evidence_under_review
+        example: 'evidence_required,evidence_under_review'
       required: false
-      description: One or more comma-separated statuses. This works like a logical *OR* operator
+      description: >-
+        One or more comma-separated statuses. This works like a logical *OR*
+        operator
     - in: query
       name: payment_id
       schema:
@@ -62,31 +83,44 @@ get:
       schema:
         type: string
       required: false
-      description: An optional reference (such as an order ID) that you can use later to identify the payment. Previously known as `TrackId`
+      description: >-
+        An optional reference (such as an order ID) that you can use later to
+        identify the payment. Previously known as `TrackId`
     - in: query
       name: payment_arn
       schema:
         type: string
       required: false
-      description: The acquirer reference number (ARN) that you can use to query the issuing bank
+      description: >-
+        The acquirer reference number (ARN) that you can use to query the
+        issuing bank
+    - in: query
+      name: payment_mcc
+      schema:
+        type: string
+      required: false
+      description: The merchant category code (MCC) of the payment (ISO 18245)
     - in: query
       name: this_channel_only
       schema:
         type: boolean
       required: false
-      description: If `true`, only returns disputes of the specific channel that the secret key is associated with. Otherwise, returns all disputes for that business
+      description: >-
+        If `true`, only returns disputes of the specific channel that the secret
+        key is associated with. Otherwise, returns all disputes for that
+        business
   responses:
-    "200":
+    '200':
       description: Disputes retrieved successfully
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/DisputePaged"
-    "401":
+            $ref: '#/components/schemas/DisputePaged'
+    '401':
       description: Unauthorized
-    "422":
+    '422':
       description: Unprocessable paging
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/PagingError"
+            $ref: '#/components/schemas/PagingError'

--- a/spec/paths/disputes@{dispute_id}.yaml
+++ b/spec/paths/disputes@{dispute_id}.yaml
@@ -1,25 +1,29 @@
 get:
   tags:
     - Disputes
+  security: 
+    - OAuth: 
+      - disputes
+      - disputes:view
+    - ApiKey: []
   summary: Get dispute details
-  description:
-    Returns all the details of a dispute using the dispute identifier.
+  description: Returns all the details of a dispute using the dispute identifier.
   parameters:
     - in: path
       name: dispute_id
       schema:
         type: string
-        pattern: "^(dsp)_(\\w{26})$"
+        pattern: '^(dsp)_(\\w{26})$'
       required: true
       description: The dispute identifier
   responses:
-    "200":
+    '200':
       description: Dispute retrieved successfully
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Dispute"
-    "401":
+            $ref: '#/components/schemas/Dispute'
+    '401':
       description: Unauthorized
-    "404":
+    '404':
       description: Dispute not found

--- a/spec/paths/disputes@{dispute_id}@accept.yaml
+++ b/spec/paths/disputes@{dispute_id}@accept.yaml
@@ -1,21 +1,28 @@
 post:
   tags:
     - Disputes
+  security: 
+    - OAuth: 
+      - disputes
+      - disputes:accept
+    - ApiKey: []
   summary: Accept dispute
-  description:
-    If a dispute is legitimate, you can choose to accept it. This will close it for you and remove it from your list of open disputes. There are no further financial implications.
+  description: >-
+    If a dispute is legitimate, you can choose to accept it. This will close it
+    for you and remove it from your list of open disputes. There are no further
+    financial implications.
   parameters:
     - in: path
       name: dispute_id
       schema:
         type: string
-        pattern: "^(dsp)_(\\w{26})$"
+        pattern: '^(dsp)_(\w{26})$'
       required: true
       description: The dispute identifier
   responses:
-    "204":
+    '204':
       description: Dispute accepted successfully
-    "401":
+    '401':
       description: Unauthorized
-    "404":
+    '404':
       description: Dispute not found

--- a/spec/paths/disputes@{dispute_id}@evidence.yaml
+++ b/spec/paths/disputes@{dispute_id}@evidence.yaml
@@ -1,83 +1,102 @@
 put:
   tags:
     - Disputes
+  security: 
+    - OAuth: 
+      - disputes
+      - disputes:provide-evidence
+    - ApiKey: []
   summary: Provide dispute evidence
-  description: |
-    Adds supporting evidence to a dispute. Before using this endpoint, you first need to [upload your files](#tag/Disputes/paths/~1files/post) using the file uploader. You will receive a file id (prefixed by `file_`) which you can then use in your request.
-    Note that this only attaches the evidence to the dispute, it does not send it to us. Once ready, you will need to submit it.
-
+  description: >
+    Adds supporting evidence to a dispute. Before using this endpoint, you first
+    need to [upload your files](#tag/Disputes/paths/~1files/post) using the file
+    uploader. You will receive a file id (prefixed by `file_`) which you can
+    then use in your request.
+    Note that this only attaches the evidence to the dispute, it does not send
+    it to us. Once ready, you will need to submit it.
     **You must provide at least one evidence type in the body of your request.**
   parameters:
     - in: path
       name: dispute_id
       schema:
         type: string
-        pattern: "^(dsp)_(\\w{26})$"
+        pattern: '^(dsp)_(\w{26})$'
       required: true
       description: The dispute identifier
   requestBody:
     content:
       application/json:
         schema:
-          $ref: "#/components/schemas/ProvideEvidenceRequest"
+          $ref: '#/components/schemas/ProvideEvidenceRequest'
         required: true
   responses:
-    "204":
+    '204':
       description: Dispute evidence provided successfully
-    "400":
+    '400':
       description: Unprocessable
-    "401":
+    '401':
       description: Unauthorized
-    "404":
+    '404':
       description: Dispute not found
-    "422":
+    '422':
       description: Unprocessable entity
-
 get:
   tags:
     - Disputes
+  security: 
+    - OAuth: 
+      - disputes
+      - disputes:view
+    - ApiKey: []
   summary: Get dispute evidence
-  description: |
-    Retrieves a list of the evidence submitted in response to a specific dispute. 
+  description: >
+    Retrieves a list of the evidence submitted in response to a specific
+    dispute. 
   parameters:
     - in: path
       name: dispute_id
       schema:
         type: string
-        pattern: "^(dsp)_(\\w{26})$"
+        pattern: '^(dsp)_(\w{26})$'
       required: true
       description: The dispute identifier
   responses:
-    "200":
+    '200':
       description: Dispute evidence retrieved successfully
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/Evidence"
-    "401":
+            $ref: '#/components/schemas/Evidence'
+    '401':
       description: Unauthorized
-    "404":
+    '404':
       description: Dispute not found
-
 post:
   tags:
     - Disputes
+  security: 
+    - OAuth: 
+      - disputes
+      - disputes:provide-evidence
+    - ApiKey: []
   summary: Submit dispute evidence
-  description: 
-    With this final request, you can submit the evidence that you have previously provided. Make sure you have provided all the relevant information before using this request.
-    You will not be able to amend your evidence once you have submitted it.
+  description: >-
+    With this final request, you can submit the evidence that you have
+    previously provided. Make sure you have provided all the relevant
+    information before using this request. You will not be able to amend your
+    evidence once you have submitted it.
   parameters:
     - in: path
       name: dispute_id
       schema:
         type: string
-        pattern: "^(dsp)_(\\w{26})$"
+        pattern: '^(dsp)_(\w{26})$'
       required: true
       description: The dispute identifier
   responses:
-    "204":
+    '204':
       description: Dispute evidence submitted successfully
-    "401":
+    '401':
       description: Unauthorized
-    "404":
+    '404':
       description: Dispute not found

--- a/spec/paths/files.yaml
+++ b/spec/paths/files.yaml
@@ -1,29 +1,35 @@
 post:
   tags:
     - Disputes
+  security: 
+    - OAuth: 
+      - disputes
+      - disputes:provide-evidence
+    - ApiKey: []
   summary: Upload file
-  description:
-    Upload a file to use as evidence in a dispute. Your file must be in either JPEG/JPG, PNG or PDF format, and be no larger than 4MB.
+  description: >-
+    Upload a file to use as evidence in a dispute. Your file must be in either
+    JPEG/JPG, PNG or PDF format, and be no larger than 4MB.
   requestBody:
     content:
       multipart/form-data:
         schema:
-          $ref: "#/components/schemas/File"
+          $ref: '#/components/schemas/File'
   responses:
-    "200":
+    '200':
       description: File uploaded successfully
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/FileUploadResponse"
+            $ref: '#/components/schemas/FileUploadResponse'
       headers:
         Cko-Request-Id:
-          $ref: "#/components/headers/Cko-Request-Id"
+          $ref: '#/components/headers/Cko-Request-Id'
         Cko-Version:
-          $ref: "#/components/headers/Cko-Version"
-    "401":
+          $ref: '#/components/headers/Cko-Version'
+    '401':
       description: Unauthorized
-    "422":
+    '422':
       description: Unprocessable
-    "429":
+    '429':
       description: Too many requests

--- a/spec/paths/files@{file_id}.yaml
+++ b/spec/paths/files@{file_id}.yaml
@@ -1,9 +1,13 @@
 get:
   tags:
     - Disputes
+  security: 
+    - OAuth: 
+      - disputes
+      - disputes:view
+    - ApiKey: []
   summary: Get file information
-  description:
-    Retrieve information about a file that was previously uploaded.
+  description: Retrieve information about a file that was previously uploaded.
   parameters:
     - in: path
       name: file_id
@@ -12,20 +16,20 @@ get:
       required: true
       description: The file identifier. It is always prefixed by `file_`.
   responses:
-    "200":
+    '200':
       description: File information retrieved successfully
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/FileResult"
+            $ref: '#/components/schemas/FileResult'
       headers:
         Cko-Request-Id:
-          $ref: "#/components/headers/Cko-Request-Id"
+          $ref: '#/components/headers/Cko-Request-Id'
         Cko-Version:
-          $ref: "#/components/headers/Cko-Version"
-    "401":
+          $ref: '#/components/headers/Cko-Version'
+    '401':
       description: Unauthorized
-    "404":
+    '404':
       description: File not found
-    "429":
+    '429':
       description: Too many requests or duplicate request detected


### PR DESCRIPTION
This feature adds support for OAuth2 scopes, disputes for partial captures (by `action_id`), arbitration states, filtering by entities and new response fields in dispute details.

- Added scopes `disputes`, `disputes:view`, `disputes:provide-evidence`, `disputes:accept`
- Updated Get Disputes with support for filtering disputes by list of `entity_ids` (includes support for sub entities) and `mcc`
- Updated Get Dispute Details response with `entity_id`, `processing_channel_id`, `action_id`, `mcc`,`3ds`, `eci` and `has_refund`
- Added `arbitration` states which will now be supported by Disputes API