### PR TITLE
Fix payment source object

### DIFF
--- a/spec/components/schemas/Sessions/CardSource.yaml
+++ b/spec/components/schemas/Sessions/CardSource.yaml
@@ -1,7 +1,7 @@
 ﻿type: object
 description: A card payment source
 allOf:
-  - $ref: "#/components/schemas/PaymentRequestSource"
+  - $ref: "#/components/schemas/SessionSource"
   - type: object
     required:
       - type

--- a/spec/components/schemas/Sessions/NetworkTokenSource.yaml
+++ b/spec/components/schemas/Sessions/NetworkTokenSource.yaml
@@ -1,7 +1,7 @@
 ﻿type: object
 description: A network token payment source
 allOf:
-  - $ref: "#/components/schemas/PaymentRequestSource"
+  - $ref: "#/components/schemas/SessionSource"
   - type: object
     required:
       - type


### PR DESCRIPTION
Session sources `CardSource` and `NetworkTokenSource` values were appearing within the payment request source property. This PR removes them.