### PR TITLE
Add more information about when response fields are required or not

### DIFF
--- a/spec/components/schemas/Sessions/Acs.yaml
+++ b/spec/components/schemas/Sessions/Acs.yaml
@@ -1,5 +1,13 @@
 type: object
-description: "The access control server information"
+required:
+  - reference_number
+  - transaction_id
+  - operator_id
+  - url
+  - challenge_mandated
+  - authentication_type
+  - authentication_method
+description: "The access control server information. Can be empty if the Session is still pending or if communication with the ACS failed"
 properties:
   reference_number:
     description: EMVCo-assigned unique identifier to track approved ACS.

--- a/spec/components/schemas/Sessions/Approved.yaml
+++ b/spec/components/schemas/Sessions/Approved.yaml
@@ -1,3 +1,3 @@
 type: boolean
-description: "Whether the authentication was successful"
+description: "Whether the authentication was successful. This will only be set if the Session is in a final state"
 example: false

--- a/spec/components/schemas/Sessions/CreateSessionAcceptedResponse.yaml
+++ b/spec/components/schemas/Sessions/CreateSessionAcceptedResponse.yaml
@@ -1,3 +1,15 @@
+required:
+  - session_secret
+  - id
+  - transaction_id
+  - scheme
+  - amount
+  - currency
+  - authentication_type
+  - authentication_category
+  - status
+  - protocol_version
+  - _links
 properties:
   session_secret:
     $ref: '#/components/schemas/SessionSecret'
@@ -13,11 +25,11 @@ properties:
     type: string
     description: Indicates the scheme this authentication is carried out against
     enum:
-      - Visa
-      - Mastercard
-      - Jcb
-      - Amex
-      - Diners
+      - visa
+      - mastercard
+      - jcb
+      - amex
+      - diners
   amount:
     $ref: '#/components/schemas/Amount'
   currency:

--- a/spec/components/schemas/Sessions/CreateSessionLinks.yaml
+++ b/spec/components/schemas/Sessions/CreateSessionLinks.yaml
@@ -1,20 +1,24 @@
 allOf:
-  - $ref: '#/components/schemas/GetSessionLinks'
+  - $ref: '#/components/schemas/GetSessionLinks'  
 properties:
   redirect:
     type: object
     description: > 
       The link where the cardholder should be redirected to. </br>
-      Only available when `hosted` value is `true`.
+      Only available and required when `hosted` value is `true`.
     properties:
+      required:
+        - href
       href:
         type: string
         maxLength: 100
         example: http://3ds2.checkout.com/interceptor/sid_y3oqhf46pyzuxjbcn2giaqnb44
   collect_channel_data:
     type: object
-    description: The URI to send device information to
+    description: The URI to send device information to. Only available if `next_actions` contains `collect_data`
     properties:
+      required:
+        - href
       href:
         type: string
         maxLength: 100

--- a/spec/components/schemas/Sessions/CreateSessionOkResponse.yaml
+++ b/spec/components/schemas/Sessions/CreateSessionOkResponse.yaml
@@ -1,5 +1,7 @@
 allOf:
   - $ref: '#/components/schemas/GetSessionResponse'
+required:
+  - session_secret
 properties:
   session_secret:
     $ref: '#/components/schemas/SessionSecret'

--- a/spec/components/schemas/Sessions/Ds.yaml
+++ b/spec/components/schemas/Sessions/Ds.yaml
@@ -1,5 +1,9 @@
 type: object
-description: "The directory server information"
+description: "The directory server information. Can be empty if the Session is pending or communication with the DS failed"
+required:
+  - ds_id
+  - reference_number
+  - transaction_id
 properties:
   ds_id:
     description: Registered Application Provider Identifier (RID) that is unique to the Payment System. RIDs are defined by the ISO 7816-5 standard. Used as part of the device data encryption process.

--- a/spec/components/schemas/Sessions/DsPublicKeys.yaml
+++ b/spec/components/schemas/Sessions/DsPublicKeys.yaml
@@ -1,5 +1,8 @@
 type: object
 description: Public certificates specific to a DS for encrypting device data and verifying ACS signed content. Required when channel is "app".  
+required:
+  - ds_public
+  - ca_public
 properties:
   ds_public: 
     type: string

--- a/spec/components/schemas/Sessions/ForbiddenErrorResponse.yaml
+++ b/spec/components/schemas/Sessions/ForbiddenErrorResponse.yaml
@@ -1,6 +1,8 @@
 type: object
-description: >-
-  Error response. Full list of error codes is on GitHub
+required:
+  - request_id
+  - error_type
+  - error_codes
 properties:
   request_id:
     type: string
@@ -10,6 +12,7 @@ properties:
     enum:
       - operation_not_allowed
   error_codes:
+    description: Error response code. Full list of error codes is on GitHub
     type: array
     items:
       type: string

--- a/spec/components/schemas/Sessions/GetBaseSessionLinks.yaml
+++ b/spec/components/schemas/Sessions/GetBaseSessionLinks.yaml
@@ -1,9 +1,13 @@
 type: object
 description: The links related to the session
+required:
+  - self
 properties:
   self:
     type: object
     description: The URI of the session
+    required:
+      - href
     properties:
       href:
         type: string

--- a/spec/components/schemas/Sessions/GetCompleteSessionLinks.yaml
+++ b/spec/components/schemas/Sessions/GetCompleteSessionLinks.yaml
@@ -5,8 +5,10 @@ allOf:
 properties:
   complete:
     type: object
-    description: The URI to signal the session as complete.
+    description: The URI to signal the session as complete. Only available if `next_actions` contains `complete`
     properties:
+      required:
+        - href
       href:
         type: string
         maxLength: 100

--- a/spec/components/schemas/Sessions/GetSessionLinks.yaml
+++ b/spec/components/schemas/Sessions/GetSessionLinks.yaml
@@ -5,40 +5,52 @@ allOf:
 properties:
   issuer_fingerprint:
     type: object
-    description: The URI to send the 3ds method completion indicator to. Use this if device information was sent when requesting a session.
+    description: >
+      The URI to send the 3ds method completion indicator to. Use this if device information was sent when requesting a session. 
+      Only available if `next_actions` contains `issuer_fingerprint`
     properties:
+      required:
+        - href
       href:
         type: string
         maxLength: 100
         example: https://api.checkout.com/sessions/sid_y3oqhf46pyzuxjbcn2giaqnb441/issuer-fingerprint
   collect_channel_data:
     type: object
-    description: The URI to send device information to
+    description: The URI to send device information to. Only available if `next_actions` contains `collect_data`
     properties:
+      required:
+        - href
       href:
         type: string
         maxLength: 100
         example: https://api.checkout.com/sessions/sid_y3oqhf46pyzuxjbcn2giaqnb441/collect-data
   three_ds_method_url:
     type: object
-    description: The URI of the Issuer FingerPrint (3DS Method)
+    description: The URI of the Issuer FingerPrint (3DS Method). Only available if `next_actions` contains `issuer_fingerprint`
     properties:
+      required:
+        - href
       href:
         type: string
         maxLength: 100
         example: https://api.hbsc.com/3dsmethod?tx=123456
   challenge_url:
     type: object
-    description: Fully qualified URL of the ACS to be used for the challenge
+    description: Fully qualified URL of the ACS to be used for the challenge. Only available if `next_actions` contains `challenge_cardholder`
     properties:
+      required:
+        - href
       href:
         type: string
         maxLength: 100
         example: https://api.hbsc.com/challenge
   complete:
     type: object
-    description: The URI to signal the session as complete.
+    description: The URI to signal the session as complete. Only available if `next_actions` contains `complete`
     properties:
+      required:
+        - href
       href:
         type: string
         maxLength: 100

--- a/spec/components/schemas/Sessions/GetSessionResponse.yaml
+++ b/spec/components/schemas/Sessions/GetSessionResponse.yaml
@@ -1,3 +1,15 @@
+required:
+  - session_secret
+  - id
+  - transaction_id
+  - scheme
+  - amount
+  - currency
+  - authentication_type
+  - authentication_category
+  - status
+  - protocol_version
+  - _links
 properties:
   id:
     $ref: '#/components/schemas/SessionId'
@@ -26,7 +38,7 @@ properties:
     example: false
   challenged:
     type: bool
-    description: Indicates whether this session involved a challenge
+    description: Indicates whether this session involved a challenge. This will only be set after communication with the scheme is finished. 
     example: true
   authentication_type:
     $ref: '#/components/schemas/AuthenticationType'
@@ -56,5 +68,9 @@ properties:
     $ref: '#/components/schemas/Cryptogram'
   eci:
     $ref: '#/components/schemas/Eci'
+  xid:
+    type: string
+    description: The xid value to use for authorization
+    example: XSUErNftqkiTdlkpSk8p32GWOFA
   _links:
     $ref: '#/components/schemas/GetSessionLinks'

--- a/spec/components/schemas/Sessions/GetSessionResponseAfterChannelDataSupplied.yaml
+++ b/spec/components/schemas/Sessions/GetSessionResponseAfterChannelDataSupplied.yaml
@@ -1,3 +1,15 @@
+required:
+  - session_secret
+  - id
+  - transaction_id
+  - scheme
+  - amount
+  - currency
+  - authentication_type
+  - authentication_category
+  - status
+  - protocol_version
+  - _links
 properties:
   id:
     $ref: '#/components/schemas/SessionId'
@@ -26,7 +38,7 @@ properties:
     example: false
   challenged:
     type: bool
-    description: Indicates whether this session involved a challenge
+    description: Indicates whether this session involved a challenge. This will only be set after communication with the scheme is finished.
     example: true
   authentication_type:
     $ref: '#/components/schemas/AuthenticationType'
@@ -54,5 +66,9 @@ properties:
     $ref: '#/components/schemas/Cryptogram'
   eci:
     $ref: '#/components/schemas/Eci'
+  xid:
+    type: string
+    description: The xid value to use for authorization
+    example: XSUErNftqkiTdlkpSk8p32GWOFA
   _links:
     $ref: '#/components/schemas/GetCompleteSessionLinks'

--- a/spec/components/schemas/Sessions/GetUpdateSessionLinks.yaml
+++ b/spec/components/schemas/Sessions/GetUpdateSessionLinks.yaml
@@ -5,32 +5,42 @@ allOf:
 properties:
   issuer_fingerprint:
     type: object
-    description: The URI to send the 3ds method completion indicator to. Use this if device information was sent when requesting a session.
+    description: >
+      The URI to send the 3ds method completion indicator to. Use this if device information was sent when requesting a session. 
+      Only available if `next_actions` contains `issuer_fingerprint`
     properties:
+      required:
+        - href
       href:
         type: string
         maxLength: 100
         example: https://api.checkout.com/sessions/sid_y3oqhf46pyzuxjbcn2giaqnb441/issuer-fingerprint
   collect_channel_data:
     type: object
-    description: The URI to send device information to
+    description: The URI to send device information to. Only available if `next_actions` contains `collect_data`
     properties:
+      required:
+        - href
       href:
         type: string
         maxLength: 100
         example: https://api.checkout.com/sessions/sid_y3oqhf46pyzuxjbcn2giaqnb441/collect-data
   three_ds_method_url:
     type: object
-    description: The URI of the Issuer FingerPrint (3DS Method)
+    description: The URI of the Issuer FingerPrint (3DS Method). Only available if `next_actions` contains `issuer_fingerprint`
     properties:
+      required:
+        - href
       href:
         type: string
         maxLength: 100
         example: https://api.hbsc.com/3dsmethod?tx=123456
   complete:
     type: object
-    description: The URI to signal the session as complete.
+    description: The URI to signal the session as complete. Only available if `next_actions` contains `complete`
     properties:
+      required:
+        - href
       href:
         type: string
         maxLength: 100

--- a/spec/components/schemas/Sessions/NextActions.yaml
+++ b/spec/components/schemas/Sessions/NextActions.yaml
@@ -1,5 +1,8 @@
 type: array
-description: Identifies what actions to take in order to complete the session.
+description: >
+  Identifies what actions to take in order to complete the session. `redirect_cardholder` only applies to Hosted Sessions.
+  `authenticate` only applies to Sessions that have been downgraded to 3DS1 (`protocol_version 1.0.2`)
+
 items:
   enum:
     - collect_channel_data
@@ -7,3 +10,5 @@ items:
     - challenge_cardholder
     - redirect_cardholder
     - complete
+    - authenticate
+    - redirect_cardholder

--- a/spec/components/schemas/Sessions/ResponseCode.yaml
+++ b/spec/components/schemas/Sessions/ResponseCode.yaml
@@ -1,5 +1,6 @@
 description: >
-  The response from the DS or ACS which indicates whether a transaction qualifies as an authenticated transaction or account verification. <br/><br/>
+  The response from the DS or ACS which indicates whether a transaction qualifies as an authenticated transaction or account verification. <br/>
+  Only available if communication with the scheme was successful and the Session is in a final state. <br/><br/>
   • Y = Authentication Verification Successful. <br/>
   • N = Not Authenticated /Account Not Verified; Transaction denied. <br/>
   • U = Authentication/ Account Verification Could Not Be Performed; Technical or other problem, as indicated in ARes or RReq. <br/>

--- a/spec/components/schemas/Sessions/ResponseReason.yaml
+++ b/spec/components/schemas/Sessions/ResponseReason.yaml
@@ -1,5 +1,7 @@
 description: >
-  The response from the DS or ACS which provides information on why the `response_code` field has the specified value.  <br/><br/>
+  The response from the DS or ACS which provides information on why the `response_code` field has the specified value.  <br/>
+  Only available when `response_code` is not `Y`.  <br/><br/>
+
   • 01 = Card authentication failed <br/>
   • 02 = Unknown Device <br/>
   • 03 = Unsupported Device <br/>

--- a/spec/components/schemas/Sessions/SessionsValidationError.yaml
+++ b/spec/components/schemas/Sessions/SessionsValidationError.yaml
@@ -1,4 +1,4 @@
-type: object
+﻿type: object
 required:
   - request_id
   - error_type
@@ -10,13 +10,11 @@ properties:
   error_type:
     type: string
     enum:
-      - invalid_input
-      - forbidden
+      - unprocessable_entity
   error_codes:
     description: Error response code. Full list of error codes is on GitHub
     type: array
     items:
       type: string
       enum:
-        - amount_required
-        - card_required
+        - currency_required

--- a/spec/paths/sessions.yaml
+++ b/spec/paths/sessions.yaml
@@ -53,7 +53,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ValidationError'
+            $ref: '#/components/schemas/SessionsValidationError'
     '501':
       description: Not Implemented
     '502':

--- a/spec/paths/sessions@{id}@collect-data.yaml
+++ b/spec/paths/sessions@{id}@collect-data.yaml
@@ -40,4 +40,4 @@ put:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorResponse'
+            $ref: '#/components/schemas/SessionsValidationError'

--- a/spec/paths/sessions@{id}@issuer-fingerprint.yaml
+++ b/spec/paths/sessions@{id}@issuer-fingerprint.yaml
@@ -40,4 +40,4 @@ put:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ErrorResponse'
+            $ref: '#/components/schemas/SessionsValidationError'


### PR DESCRIPTION
- Adds required flags for the response fields of Sessions
- Adds `xid` as a new response field for sessions
- Updates the `next_actions` and `status` enums to document the 3DS1 downgrade flow
