### PR TITLE
Add latest version of redoc

### DIFF
--- a/web/index.css
+++ b/web/index.css
@@ -112,7 +112,11 @@ body {
 
 /* General text elements */
 
-.redoc-wrap p, h1, h1 a, h3, th, td, span.sc-jKJlTe.eZZMfQ {
+.redoc-wrap p, h1, h1 a, h3, th, td, span.sc-jKJlTe.eZZMfQ,label.jIStei,
+span.sc-fzqKxP.dvqdvD,
+h5, 
+span.sc-fzpkJw.hctKJM, 
+body.dark button span {
   color: var(--secondary-text) !important;
 }
 
@@ -283,7 +287,7 @@ span.sc-cHGsZl.sc-jqCOkK.beUper {
   background: none;
 }
 
-code, .evgDyP, .sc-cHGsZl.sc-jbKcbu.bMfIUD {
+code, .evgDyP, .sc-cHGsZl.sc-jbKcbu.bMfIUD{
   font-family: Courier, monospace !important;
   font-style: italic !important;
   background: var(--S10) !important;
@@ -338,14 +342,14 @@ td.dz44d2-1 {
   font-family: Courier, monospace;
 }
 
-li.sc-eNQAEJ.gYsnwL {
+.fvfRMB { /*Redoc upgrate changed these to buttons not li*/
   background: var(--primary-button) !important;
   border: 1px solid var(--primary-button) !important;
   font-weight: 500;
   color: var(--primary-button-color) !important;
 }
 
-li.sc-eNQAEJ.jdXjUh {
+.kCktTl {
   color: var(--primary-text);
   border: 1px solid var(--border);
   background-color: unset;
@@ -766,6 +770,65 @@ code span {
   fill: var(--secondary-text) !important;
 }
 
-.sc-bxivhb li {
+div.sc-AxhCb.iWvlZG li {
   color: var(--secondary-text) !important;
+}
+
+/*Chrisi quick fixes */
+
+/*DARK THEME CHANGES*/
+
+/*Just stuck to the navy color - so had to remove it and then insert it with css*/
+body.dark div.logiML
+ {
+  background-color: transparent !important;
+  background: url('favicons/white-logo.svg') no-repeat center;
+  padding-top: 50px;
+}
+body.dark div.sc-fzppip img {
+  display: none;
+}
+
+/* LIGHT THEME CHANGES */
+
+/*Logo really close to the top on the light theme*/
+body.light div.logiML {
+  padding-top: 40px;
+}
+
+/*BOTH THEME CHANGES*/
+
+/*New darker background appeared */
+
+body.light div.eIeJha,
+body.dark div.eIeJha {
+  background-color: transparent;
+}
+
+/*There are new boxes above the response examples*/
+
+body.light span.yvLAA {
+  font-weight: 800;
+  top: 0;
+  color: var(--cko-dark-blue);
+}
+
+body.light div.hHgrjJ {
+  color: white;
+  padding: 1.5em 1.6em 0.9em 0.9em;
+}
+
+body.light div.iFDKZT.iFDKZT {
+  padding: 1.2em 2em 0.9em 0.9em;
+}
+
+/*Plus symbols were white on the responses*/
+
+.fAIZSm .collapsed > .collapser::after {
+  color: var(--code-param);
+}
+
+/*Changing the endpoint drop down to navy*/
+button.sc-qQmou.hnIgFW{
+  background-color: var(--url-area) !important;
 }

--- a/web/index.html
+++ b/web/index.html
@@ -35,6 +35,7 @@
     // Set theme based on local storage
     var toggle = document.querySelector('.toggle-track');
     var theme = localStorage.getItem("theme");
+    
     if (theme) {
       document.body.className = "";
       document.body.classList.add(theme);
@@ -58,11 +59,14 @@
         document.body.classList.add("dark");
       }
     })
+
+   
   </script>
   <redoc spec-url="./swagger.yaml" hide-loading hide-download-button>
   </redoc>
   <script
-    src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.31/bundles/redoc.standalone.js"> </script>
+    src="https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js"> </script>
+    > </script>
 </body>
 
 </html>


### PR DESCRIPTION
I saw we didn't have the latest version of Redoc so added the cdn link in. That messed up a lot of the styles because I think some of the class names redoc gives us has changed. I've added some fixes. Left comments to explain what I've done and why. I had a search before I created new selectors just in case. Considering we'll be re-desiging at some point, didn't want to spend too much time on it! 