### PR TITLE
Added resolved_reason property to dispute docs

### DIFF
--- a/spec/components/schemas/Disputes/Dispute.yaml
+++ b/spec/components/schemas/Disputes/Dispute.yaml
@@ -35,6 +35,11 @@ properties:
     description: The current status of the dispute
     enum: [evidence_required, evidence_under_review, resolved, won, lost, canceled, expired, accepted, arbitration_under_review, arbitration_won, arbitration_lost]
     example: "evidence_required"
+  resolved_reason:
+    type: string
+    description: If the dispute is automatically resolved, `resolved_reason` will contain the reason why it was resolved
+    enum: [rapid_dispute_resolution, negative_amount, already_refunded]
+    example: "already_refunded"
   relevant_evidence:
     type: array
     description: <i>This list and the dispute categories will change over time. Your evidence logic should be informed by this field, not hard coded.</i>

--- a/spec/components/schemas/Disputes/FileResult.yaml
+++ b/spec/components/schemas/Disputes/FileResult.yaml
@@ -32,4 +32,4 @@ properties:
         description: The temporary file download URL. This expires after 60 minutes
         properties:    
           href:
-            example: "https://cabinet-upload-prod.s3.eu-west-1.amazonaws.com/ucdac/ucdac/6lbss42ezvoufcb2beo76rvwly?X-Amz-Expires=3600&x-amz-security-token=FQoDYXdzENL%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEa"
+            example: "https://file-bucket.s3.eu-west-1.amazonaws.com/ucdac/ucdac/6lbss42ezvoufcb2beo76rvwly?X-Amz-Expires=3600&x-amz-security-token=FQoDYXdzENL%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEa"


### PR DESCRIPTION
- Based on latest work done in Disputes we need to add a new property to `Get Dispute Details` response
- Also removed real reference to file bucket in the `Get file information` response and replaced by dummy address