### PR TITLE
Doc team copy amends

### DIFF
--- a/spec/components/schemas/Marketplace/DateOfBirth.yaml
+++ b/spec/components/schemas/Marketplace/DateOfBirth.yaml
@@ -1,22 +1,22 @@
 type: object
 title: DateOfBirth
-description: The date of birth according to the Gregorian calendar
+description: The date of birth of the person according to the Gregorian calendar.
 properties:
   day:
     type: number
-    description: The calendar day of the month they were born
+    description: The calendar day of the month they were born.
     minimum: 1
     maximum: 31
     example: 16
   month:
     type: number
-    description: The month of the year they were born
+    description: The month of the year they were born.
     minimum: 1
     maximum: 12
     example: 03
   year:
     type: number  
-    description: The year they were born
+    description: The year they were born.
     minimum: 1900
     example: 1985
 required:

--- a/spec/components/schemas/Marketplace/DateOfBirth.yaml
+++ b/spec/components/schemas/Marketplace/DateOfBirth.yaml
@@ -1,5 +1,5 @@
 type: object
-title: DateOfBirth
+title: Date of birth
 description: The date of birth of the person according to the Gregorian calendar.
 properties:
   day:

--- a/spec/components/schemas/Marketplace/DocumentUploadRequest.yaml
+++ b/spec/components/schemas/Marketplace/DocumentUploadRequest.yaml
@@ -1,5 +1,5 @@
 type: object
-title: DocumentUploadRequest
+title: Document upload request
 properties:
   type:
     type: string

--- a/spec/components/schemas/Marketplace/DocumentUploadRequest.yaml
+++ b/spec/components/schemas/Marketplace/DocumentUploadRequest.yaml
@@ -3,7 +3,7 @@ title: DocumentUploadRequest
 properties:
   type:
     type: string
-    description: The type of document
+    description: The type of document.
     enum:
       - passport
       - national_identity_card

--- a/spec/components/schemas/Marketplace/EntityAddress.yaml
+++ b/spec/components/schemas/Marketplace/EntityAddress.yaml
@@ -9,13 +9,13 @@ properties:
     example: "90 Tottenham Court Road"
   address_line2:
     type: string
-    description: "The second line of the address"
+    description: "The second line of the address."
     minLength: 0
     maxLength: 300
     example: null
   city:
     type: string
-    description: "The address city"
+    description: "The address city."
     minLength: 2
     maxLength: 300
     example: "London"

--- a/spec/components/schemas/Marketplace/EntityAddress.yaml
+++ b/spec/components/schemas/Marketplace/EntityAddress.yaml
@@ -3,7 +3,7 @@ title: Address
 properties:
   address_line1:
     type: string
-    description: "The first line of the address. Note that the length of line 1 and line 2 combined must be at least 5 characters long"
+    description: "The first line of the address. Note that the length of line 1 and line 2 combined must be at least 5 characters long."
     minLength: 1
     maxLength: 300
     example: "90 Tottenham Court Road"
@@ -21,19 +21,20 @@ properties:
     example: "London"
   state:
     type: string
-    description: "The address state (in the US, this is required and needs to be an ISO 3166-1 state code)"
+    description: "The address state. (In the US, this is required and needs to be an ISO 3166-1 state code.)"
     minLength: 0
     maxLength: 300
     example: null
   zip:
     type: string
-    description: "The address zip/postal code"
+    pattern: ^\d{5}(?:[-\s]\d{4})?$
+    description: "The address zip/postal code."
     minLength: 1
     maxLength: 16
     example: "W1T4TJ"
   country:
     type: string
-    description: The two-letter <a href="https://docs.checkout.com/docs/country-codes" target="blank">ISO country code</a> of the address
+    description: The two-letter <a href="https://docs.checkout.com/docs/country-codes" target="blank">ISO country code</a> of the address.
     minLength: 2
     maxLength: 2
     pattern: "[a-zA-Z]{2}"

--- a/spec/components/schemas/Marketplace/EntityBasicResponse.yaml
+++ b/spec/components/schemas/Marketplace/EntityBasicResponse.yaml
@@ -1,5 +1,5 @@
 type: object
-title: BasicResponse
+title: Basic response
 readOnly: true
 properties:
   id:

--- a/spec/components/schemas/Marketplace/EntityBasicResponse.yaml
+++ b/spec/components/schemas/Marketplace/EntityBasicResponse.yaml
@@ -4,11 +4,11 @@ readOnly: true
 properties:
   id:
     type: string
-    description: The unique identifier of the sub-entity
+    description: The unique identifier of the sub-entity.
     example: ent_wxglze3wwywujg4nna5fb7ldli
   reference:
     type: string
-    description: A unique reference you can later use to identify this sub-entity
+    description: A unique reference you can later use to identify this sub-entity.
     minLength: 1
     maxLength: 15
     example: superhero1234

--- a/spec/components/schemas/Marketplace/EntityBasicResponseWithLinks.yaml
+++ b/spec/components/schemas/Marketplace/EntityBasicResponseWithLinks.yaml
@@ -1,5 +1,5 @@
 type: object
-title: BasicResponseWithLinks
+title: Basic response with links
 allOf:
   - $ref: "#/components/schemas/EntityBasicResponse"
   - $ref: "#/components/schemas/EntityLinks"

--- a/spec/components/schemas/Marketplace/EntityCapabilities.yaml
+++ b/spec/components/schemas/Marketplace/EntityCapabilities.yaml
@@ -3,19 +3,19 @@ title: Capabilities
 properties:
   payments:
     type: object
-    description: "Payment related capabilities of a sub-entity"
+    description: "Payment related capabilities of a sub-entity."
     properties:
       enabled:
         type: boolean
-        description: True if payments are enabled
+        description: True if payments are enabled.
     example:
       enabled: false
   payouts:
     type: object
-    description: "Payout related capabilities of a sub-entity"
+    description: "Payout related capabilities of a sub-entity."
     properties:
       enabled:
         type: boolean
-        description: "True if payouts are enabled"
+        description: "True if payouts are enabled."
     example:
       enabled: false

--- a/spec/components/schemas/Marketplace/EntityCompany.yaml
+++ b/spec/components/schemas/Marketplace/EntityCompany.yaml
@@ -4,34 +4,34 @@ description: "Information about the company represented by the sub-entity. Inclu
 properties:
   business_registration_number:
     type: string
-    description: "The Business Registration Number of the sub-entity, such as Commercial Registration, Ministry of Commerce certificate number or equivalent registration number"
+    description: "The Business Registration Number of the sub-entity, such as Commercial Registration, Ministry of Commerce certificate number or equivalent registration number."
     minLength: 2
     maxLength: 16
     example: "452349600005"
   legal_name:
     type: string
-    description: "The legal name of the sub-entity"
+    description: "The legal name of the sub-entity."
     minLength: 2
     maxLength: 300
     example: Super Hero Masks Inc.
   trading_name:
     type: string
-    description: "The trading name of the sub-entity, also referred to as 'doing business as'"
+    description: "The trading name of the sub-entity, also referred to as 'doing business as'."
     minLength: 2
     maxLength: 300
     example: Super Hero Masks
   principal_address:
-    description: "The primary location of the company where business is performed"
+    description: "The primary location of the company where business is performed."
     allOf:
       - $ref: "#/components/schemas/EntityAddress"
   registered_address:
-    description: "The registered address of the company"
+    description: "The registered address of the company."
     allOf:
       - $ref: "#/components/schemas/EntityAddress"
   representatives:
     type: array
     title: Representatives
-    description: "Information about representatives of this company"
+    description: "Information about representatives of this company."
     minItems: 1
     maxItems: 5
     items:

--- a/spec/components/schemas/Marketplace/EntityContactDetails.yaml
+++ b/spec/components/schemas/Marketplace/EntityContactDetails.yaml
@@ -1,6 +1,6 @@
 type: object
-title: ContactDetails
-description: "Contact details of this sub-entity"
+title: Contact details
+description: "Contact details of this sub-entity."
 properties:
   phone:
     $ref: "#/components/schemas/EntityPhone"

--- a/spec/components/schemas/Marketplace/EntityCreateRequest.yaml
+++ b/spec/components/schemas/Marketplace/EntityCreateRequest.yaml
@@ -3,18 +3,18 @@ title: CreateRequest
 properties:
   reference:
     type: string
-    description: A unique reference you can later use to identify this sub-entity
+    description: A unique reference you can later use to identify this sub-entity.
     minLength: 1
     maxLength: 15
     example: superhero1234
   contact_details:
-    title: ContactDetails
+    title: Contact details
     allOf:
       - $ref: "#/components/schemas/EntityContactDetails"
       - type: object
         properties:
           phone:
-            description: "The phone number of the sub-entity"
+            description: "The phone number of the sub-entity."
             allOf:
               - $ref: "#/components/schemas/EntityPhone"
             required:
@@ -39,25 +39,25 @@ properties:
     properties:
       business_registration_number:
         type: string
-        description: "The Business Registration Number of the sub-entity, such as Commercial Registration, Ministry of Commerce certificate number or equivalent registration number"
+        description: "The Business Registration Number of the sub-entity, such as Commercial Registration, Ministry of Commerce certificate number or equivalent registration number."
         minLength: 2
         maxLength: 16
         example: "452349600005"
       legal_name:
         type: string
-        description: "The legal name of the sub-entity"
+        description: "The legal name of the sub-entity."
         minLength: 2
         maxLength: 300
         example: Super Hero Masks Inc.
       trading_name:
         type: string
-        description: "The trading name of the sub-entity, also referred to as 'doing business as'"
+        description: "The trading name of the sub-entity, also referred to as 'doing business as'."
         minLength: 2
         maxLength: 300
         example: Super Hero Masks
       principal_address:
         title: Address
-        description: "The primary location of the company where business is performed"
+        description: "The primary location of the company where business is performed."
         allOf:
           - $ref: "#/components/schemas/EntityAddress"
         required:
@@ -67,7 +67,7 @@ properties:
           - country
       registered_address:
         title: Address
-        description: "The registered address of the company"
+        description: "The registered address of the company."
         allOf:
           - $ref: "#/components/schemas/EntityAddress"
         required:
@@ -78,7 +78,7 @@ properties:
       representatives:
         type: array
         title: Representatives
-        description: "Information about representatives of this company"
+        description: "Information about representatives of this company."
         minItems: 1
         maxItems: 5
         items:
@@ -104,36 +104,36 @@ properties:
     properties:
       first_name:
         type: string
-        description: "The individual's first name"
+        description: "The person's first name."
         minLength: 2
         maxLength: 50
         example: "John"
       middle_name:
         type: string
-        description: "The individual's middle name"
+        description: "The person's middle name."
         maxLength: 50
         example: "Paul"
       last_name:
         type: string
-        description: "The individual's last name"
+        description: "The person's last name."
         minLength: 2
         maxLength: 50
         example: "Doe"
       trading_name:
         type: string
-        description: "If applicable, the individual's trading name"
+        description: "If applicable, the person's trading name."
         minLength: 2
         maxLength: 300
         example: Super Hero Masks
       national_tax_id:
         type: string
-        description: "The sub-entity's Tax Identification Code; for example, a Value Added Tax (VAT) Number in the UK"
+        description: "The sub-entity's Tax Identification Code. For example, a Value Added Tax (VAT) number in the UK."
         minLength: 2
         maxLength: 16
         example: "1234567"
       registered_address:
         title: Address
-        description: "The registered address of the individual"
+        description: "The registered address of the person."
         allOf:
           - $ref: "#/components/schemas/EntityAddress"
         required:

--- a/spec/components/schemas/Marketplace/EntityCreateRequest.yaml
+++ b/spec/components/schemas/Marketplace/EntityCreateRequest.yaml
@@ -127,7 +127,7 @@ properties:
         example: Super Hero Masks
       national_tax_id:
         type: string
-        description: "The sub-entity's Tax Identification Code. For example, a Value Added Tax (VAT) number in the UK."
+        description: "The sub-entity's tax identification code. For example, a value added tax (VAT) number in the UK."
         minLength: 2
         maxLength: 16
         example: "1234567"

--- a/spec/components/schemas/Marketplace/EntityExtendedResponse.yaml
+++ b/spec/components/schemas/Marketplace/EntityExtendedResponse.yaml
@@ -14,7 +14,7 @@ allOf:
         $ref: "#/components/schemas/EntityIndividual"
       instruments:
         type: array
-        description: A collection of payment instruments added for this sub-entity
+        description: A collection of payment instruments added for this sub-entity.
         items:
           $ref: "#/components/schemas/MarketplaceInstrumentReference"
   - $ref: "#/components/schemas/EntityLinks"

--- a/spec/components/schemas/Marketplace/EntityIdentification.yaml
+++ b/spec/components/schemas/Marketplace/EntityIdentification.yaml
@@ -25,7 +25,7 @@ properties:
         example: passport
       front:
         type: string
-        description: The id of the front side of the document as represented within Checkout.com systems.
+        description: The ID of the front side of the document as represented within Checkout.com systems.
         example: file_wxglze3wwywujg4nna5fb7ldli
       back:
         type: string

--- a/spec/components/schemas/Marketplace/EntityIdentification.yaml
+++ b/spec/components/schemas/Marketplace/EntityIdentification.yaml
@@ -1,6 +1,6 @@
 type: object
 title: Identification
-description: Identification details of an individual, which is used for verification.
+description: Identification details of an individual, used for verification.
 properties:
   national_id_number:
     type: string

--- a/spec/components/schemas/Marketplace/EntityIdentification.yaml
+++ b/spec/components/schemas/Marketplace/EntityIdentification.yaml
@@ -29,7 +29,7 @@ properties:
         example: file_wxglze3wwywujg4nna5fb7ldli
       back:
         type: string
-        description: The id of the back side of the document as represented within Checkout.com systems. The back of the document is required for all document types apart from passports.
+        description: The ID of the back side of the document as represented within Checkout.com systems. The back of the document is required for all document types apart from passports.
         example: file_adglze3wwywujg4nna5fb7l1sg
     readOnly: true
     required:

--- a/spec/components/schemas/Marketplace/EntityIdentification.yaml
+++ b/spec/components/schemas/Marketplace/EntityIdentification.yaml
@@ -1,20 +1,20 @@
 type: object
 title: Identification
-description: Identification details of an individual that are used for verification
+description: Identification details of an individual, which is used for verification.
 properties:
   national_id_number:
     type: string
-    description: "The official ID number, as applicable in the representative's country (For US, this must be numeric otherwise alpha-numeric)"
+    description: "The official id number, as applicable in the representative's country. (For US, this must be numeric; otherwise, alpha-numeric.)"
     minLength: 1
     maxLength: 25
     example: AB123456C
   document:
     type: object
-    description: "A legal document used to verify identity"
+    description: "A legal document used to verify identity."
     properties: 
       type:
         type: string
-        description: The type of document
+        description: The type of document.
         enum:
           - passport
           - national_identity_card
@@ -25,11 +25,11 @@ properties:
         example: passport
       front:
         type: string
-        description: The ID of the front side of the document as represented within Checkout.com systems
+        description: The id of the front side of the document as represented within Checkout.com systems.
         example: file_wxglze3wwywujg4nna5fb7ldli
       back:
         type: string
-        description: The ID of the back side of the document as represented within Checkout.com systems. The back of the document is required for all document types apart from passports.
+        description: The id of the back side of the document as represented within Checkout.com systems. The back of the document is required for all document types apart from passports.
         example: file_adglze3wwywujg4nna5fb7l1sg
     readOnly: true
     required:

--- a/spec/components/schemas/Marketplace/EntityIdentification.yaml
+++ b/spec/components/schemas/Marketplace/EntityIdentification.yaml
@@ -4,7 +4,7 @@ description: Identification details of an individual, which is used for verifica
 properties:
   national_id_number:
     type: string
-    description: "The official id number, as applicable in the representative's country. (For US, this must be numeric; otherwise, alpha-numeric.)"
+    description: "The official ID number, as applicable in the representative's country. (For US, this must be numeric; otherwise, alpha-numeric.)"
     minLength: 1
     maxLength: 25
     example: AB123456C

--- a/spec/components/schemas/Marketplace/EntityIndividual.yaml
+++ b/spec/components/schemas/Marketplace/EntityIndividual.yaml
@@ -4,41 +4,41 @@ description: "Information about the individual represented by the sub-entity. In
 properties:
   first_name:
     type: string
-    description: "The individual's first name"
+    description: "The person's first name"
     minLength: 2
     maxLength: 50
     example: "John"
   middle_name:
     type: string
-    description: "The individual's middle name"
+    description: "The person's middle name"
     maxLength: 50
     example: "Paul"
   last_name:
     type: string
-    description: "The individual's last name"
+    description: "The person's last name"
     minLength: 2
     maxLength: 50
     example: "Doe"
   legal_name:
     type: string
-    description: "The legal name of the individual sub-entity"
+    description: "The legal name of the person."
     example: John Paul Doe
     readOnly: true
   trading_name:
     type: string
-    description: "If applicable, the individual's trading name"
+    description: "If applicable, the person's trading name."
     minLength: 2
     maxLength: 300
     example: Super Hero Masks
   national_tax_id:
     type: string
-    description: "The sub-entity's Tax Identification Code; for example, a Value Added Tax (VAT) Number in the UK"
+    description: "The sub-entity's Tax Identification Code. For example, a Value Added Tax (VAT) number in the UK."
     minLength: 2
     maxLength: 16
     example: "1234567"
   registered_address:
     title: Address
-    description: "The registered address of the individual"
+    description: "The registered address of the person."
     allOf:
       - $ref: "#/components/schemas/EntityAddress"
   date_of_birth:

--- a/spec/components/schemas/Marketplace/EntityIndividual.yaml
+++ b/spec/components/schemas/Marketplace/EntityIndividual.yaml
@@ -10,7 +10,7 @@ properties:
     example: "John"
   middle_name:
     type: string
-    description: "The person's middle name"
+    description: "The person's middle name."
     maxLength: 50
     example: "Paul"
   last_name:

--- a/spec/components/schemas/Marketplace/EntityIndividual.yaml
+++ b/spec/components/schemas/Marketplace/EntityIndividual.yaml
@@ -15,7 +15,7 @@ properties:
     example: "Paul"
   last_name:
     type: string
-    description: "The person's last name"
+    description: "The person's last name."
     minLength: 2
     maxLength: 50
     example: "Doe"

--- a/spec/components/schemas/Marketplace/EntityIndividual.yaml
+++ b/spec/components/schemas/Marketplace/EntityIndividual.yaml
@@ -4,7 +4,7 @@ description: "Information about the individual represented by the sub-entity. In
 properties:
   first_name:
     type: string
-    description: "The person's first name"
+    description: "The person's first name."
     minLength: 2
     maxLength: 50
     example: "John"

--- a/spec/components/schemas/Marketplace/EntityPhone.yaml
+++ b/spec/components/schemas/Marketplace/EntityPhone.yaml
@@ -3,7 +3,7 @@ title: Phone
 properties:
   number:
     type: string
-    description: "The phone number. This must not contain non-numeric characters and can't contain only zeros (For US numbers: Cannot start with 0 or 1 and must be at least 10 characters in length)"
+    description: "The phone number. This must only contain numeric characters and can't contain only zeros. (For US numbers: It cannot start with 0 or 1 and must be at least 10 characters in length.)"
     minLength: 8
     maxLength: 16
     example: "2345678910"

--- a/spec/components/schemas/Marketplace/EntityProfile.yaml
+++ b/spec/components/schemas/Marketplace/EntityProfile.yaml
@@ -4,7 +4,7 @@ description: "Information about the profile of the sub-entity, primarily regardi
 properties:
   urls:
     type: array
-    description: "A collection of website URLs the sub-entity accepts payments on. Separate different URLs with a space and make sure the entry is no longer than 4,000 characters (including the space).<br><br>For example, 'www.example1.com www.example2.com'."
+    description: "A collection of website URLs the sub-entity accepts payments on. The array of items, when joined together with a space, should be no longer than 4,000 characters."
     minItems: 1
     maxItems: 100
     items:

--- a/spec/components/schemas/Marketplace/EntityProfile.yaml
+++ b/spec/components/schemas/Marketplace/EntityProfile.yaml
@@ -4,29 +4,30 @@ description: "Information about the profile of the sub-entity, primarily regardi
 properties:
   urls:
     type: array
-    description: "A collection of URLs of websites the sub-entity accepts payments on. All URLs joined with a space must be no longer than 4000 characters."
+    description: "A collection of website URLs the sub-entity accepts payments on. Separate different URLs with a space and make sure the entry is no longer than 4,000 characters (including the space).<br><br>For example, 'www.example1.com www.example2.com'."
     minItems: 1
     maxItems: 100
     items:
       type: string
-      description: "A URL of a website the sub-entity accepts payments on"
+      description: "A URL of a website the sub-entity accepts payments on."
       minLength: 4
       maxLength: 300
       example: "https://www.superheroexample.com"
   mccs:
     type: array
-    description: "A collection of 4-digit ISO 18245 merchant category codes classifying the sub-entity's industry"
+    description: "A collection of 4-digit ISO 18245 merchant category codes classifying the sub-entity's industry."
     minItems: 1
     maxItems: 5
     items:
       type: string
-      description: "A 4-digit ISO 18245 merchant category code classifying the sub-entity's industry"
+      description: "A 4-digit ISO 18245 merchant category code classifying the sub-entity's industry."
       minLength: 4
       maxLength: 4
       example: "5669"
   default_holding_currency:
     type: string
-    description: "The ISO 4217 currency code this entity processes funds with."
+    description: | 
+      The ISO 4217 currency code this sub-entity processes funds with. Payments processed on behalf of this sub-entity will be routed to and held in this currency.<br><br>For example, the currency code 'AUD' represents the Australian Dollar in Austrailia. For more information, check out our <a href="https://docs.checkout.com/resources/codes/currency-codes" target="_blank">documentation on currency codes</a>.
     format: ISO 4217
     minLength: 3
     maxLength: 3

--- a/spec/components/schemas/Marketplace/EntityRepresentative.yaml
+++ b/spec/components/schemas/Marketplace/EntityRepresentative.yaml
@@ -3,43 +3,43 @@ title: Representative
 properties:
   id:
     type: string
-    description: "The id of the company sub-entity representative"
+    description: "The id of the company's sub-entity representative."
     example: "rep_a6omkepkkfiutynatam37wrfc4"
     readOnly: true
   first_name:
     type: string
-    description: "The person's first name"
+    description: "The person's first name."
     minLength: 2
     maxLength: 300
     example: "John"
   middle_name:
     type: string
-    description: "The person's middle name"
+    description: "The person's middle name."
     maxLength: 300
     example: null
   last_name:
     type: string
-    description: "The person's last name"
+    description: "The person's last name."
     minLength: 2
     maxLength: 300
     example: "Doe"
   address:
     title: Address
-    description: "The representative's address"
+    description: "The person's address."
     allOf:
       - $ref: "#/components/schemas/EntityAddress"
       - type: object
         properties:
           address_line1:
             type: string
-            description: "The first line of the address. If provided, the length of line 1 and line 2 combined must be at least 5 characters long"
+            description: "The first line of the address. If provided, the length of line 1 and line 2 combined must be at least 5 characters long."
             minLength: 0
             maxLength: 300
             example: "90 Tottenham Court Road"
   identification:
     $ref: "#/components/schemas/EntityIdentification"
   phone:
-    description: "The phone number of the representative"
+    description: "The phone number of the person."
     allOf:
       - $ref: "#/components/schemas/EntityPhone"
   date_of_birth:

--- a/spec/components/schemas/Marketplace/EntityUpdateRequest.yaml
+++ b/spec/components/schemas/Marketplace/EntityUpdateRequest.yaml
@@ -121,7 +121,7 @@ properties:
         example: Super Hero Masks
       national_tax_id:
         type: string
-        description: "The sub-entity's Tax Identification Code. For example, a Value Added Tax (VAT) number in the UK."
+        description: "The sub-entity's tax identification code. For example, a value added tax (VAT) number in the UK."
         minLength: 2
         maxLength: 16
         example: "1234567"

--- a/spec/components/schemas/Marketplace/EntityUpdateRequest.yaml
+++ b/spec/components/schemas/Marketplace/EntityUpdateRequest.yaml
@@ -2,13 +2,13 @@ type: object
 title: UpdateRequest
 properties:
   contact_details:
-    title: ContactDetails
+    title: Contact details
     allOf:
       - $ref: "#/components/schemas/EntityContactDetails"
       - type: object
         properties:
           phone:
-            description: "The phone number of the sub-entity"
+            description: "The phone number of the sub-entity."
             allOf:
               - $ref: "#/components/schemas/EntityPhone"
             required:
@@ -33,25 +33,25 @@ properties:
     properties:
       business_registration_number:
         type: string
-        description: "The Business Registration Number of the sub-entity, such as Commercial Registration, Ministry of Commerce certificate number or equivalent registration number"
+        description: "The Business Registration Number of the sub-entity, such as Commercial Registration, Ministry of Commerce certificate number or equivalent registration number."
         minLength: 2
         maxLength: 16
         example: "452349600005"
       legal_name:
         type: string
-        description: "The legal name of the sub-entity"
+        description: "The legal name of the sub-entity."
         minLength: 2
         maxLength: 300
         example: Super Hero Masks Inc.
       trading_name:
         type: string
-        description: "The trading name of the sub-entity, also referred to as 'doing business as'"
+        description: "The trading name of the sub-entity, also referred to as 'doing business as'."
         minLength: 2
         maxLength: 300
         example: Super Hero Masks
       principal_address:
         title: Address
-        description: "The primary location of the company where business is performed"
+        description: "The primary location of the company where business is performed."
         allOf:
           - $ref: "#/components/schemas/EntityAddress"
         required:
@@ -61,7 +61,7 @@ properties:
           - country
       registered_address:
         title: Address
-        description: "The registered address of the company"
+        description: "The registered address of the company."
         allOf:
           - $ref: "#/components/schemas/EntityAddress"
         required:
@@ -98,36 +98,36 @@ properties:
     properties:
       first_name:
         type: string
-        description: "The individual's first name"
+        description: "The individual's first name."
         minLength: 2
         maxLength: 50
         example: "John"
       middle_name:
         type: string
-        description: "The individual's middle name"
+        description: "The individual's middle name."
         maxLength: 50
         example: "Paul"
       last_name:
         type: string
-        description: "The individual's last name"
+        description: "The individual's last name."
         minLength: 2
         maxLength: 50
         example: "Doe"
       trading_name:
         type: string
-        description: "If applicable, the individual's trading name"
+        description: "If applicable, the individual's trading name."
         minLength: 2
         maxLength: 300
         example: Super Hero Masks
       national_tax_id:
         type: string
-        description: "The sub-entity's Tax Identification Code; for example, a Value Added Tax (VAT) Number in the UK"
+        description: "The sub-entity's Tax Identification Code. For example, a Value Added Tax (VAT) number in the UK."
         minLength: 2
         maxLength: 16
         example: "1234567"
       registered_address:
         title: Address
-        description: "The registered address of the individual"
+        description: "The registered address of the individual."
         allOf:
           - $ref: "#/components/schemas/EntityAddress"
         required:

--- a/spec/components/schemas/Marketplace/Instruments/MarketplaceAccountHolder.yaml
+++ b/spec/components/schemas/Marketplace/Instruments/MarketplaceAccountHolder.yaml
@@ -1,9 +1,9 @@
 type: object
-title: AccountHolder
+title: Account holder
 properties:
   type:
     title: Type
-    description: The type of account holder
+    description: The type of account holder.
     type: string
     enum:
       - individual
@@ -11,57 +11,57 @@ properties:
       - government
   first_name:
     title: FirstName
-    description: "The account holder's first name. Required if `type` is `individual`"
+    description: "The account holder's first name. Required if `type` is `individual`."
     type: string
     example: Peter
   last_name:
     title: LastName
-    description: "The account holder's last name. Required if `type` is `individual`"
+    description: "The account holder's last name. Required if `type` is `individual`."
     type: string
     example: Parker
   company_name:
     title: CompanyName
-    description: "The legal name of a registered company that holds the account. Required if `type` is `corporate`"
+    description: "The legal name of a registered company that holds the account. Required if `type` is `corporate`."
     type: string
     example: Super Hero Masks Inc.
   tax_id:
     title: TaxId
-    description: The account holder's tax number/reference
+    description: The account holder's tax number/reference.
     type: string
     example: "123456"
   date_of_birth:
     title: DateOfBirth
-    description: The account holder's date of birth
+    description: The account holder's date of birth.
     allOf:
       - $ref: "#/components/schemas/DateOfBirth"
   country_of_birth:
     title: CountryOfBirth
-    description: The two-letter ISO country code of the account holder's country of birth
+    description: The two-letter ISO country code of the account holder's country of birth.
     type: string
     format: ISO 3166-1
     example: "GB"
   residential_status:
     title: ResidentalStatus
-    description: The two-letter ISO country code of the account holder's country of birth
+    description: The two-letter ISO country code of the account holder's country of birth.
     type: string
     enum:
       - resident
       - non_resident
   billing_address:
     title: BillingAddress
-    description: The billing address of the account holder
+    description: The billing address of the account holder.
     allOf:
       - $ref: "#/components/schemas/EntityAddress"
   phone:
     title: Phone
-    description: The phone number of the account holder
+    description: The phone number of the account holder.
     allOf:
       - $ref: "#/components/schemas/EntityPhone"
   identification:
     $ref: "#/components/schemas/MarketplaceAccountHolderIdentification"
   email:
     title: email
-    description: The account holder's email address
+    description: The account holder's email address.
     type: string
     format: email
     example: peter.parker@superhero.masks

--- a/spec/components/schemas/Marketplace/Instruments/MarketplaceAccountHolder.yaml
+++ b/spec/components/schemas/Marketplace/Instruments/MarketplaceAccountHolder.yaml
@@ -10,45 +10,45 @@ properties:
       - corporate
       - government
   first_name:
-    title: FirstName
+    title: First name
     description: "The account holder's first name. Required if `type` is `individual`."
     type: string
     example: Peter
   last_name:
-    title: LastName
+    title: Last name
     description: "The account holder's last name. Required if `type` is `individual`."
     type: string
     example: Parker
   company_name:
-    title: CompanyName
+    title: Company name
     description: "The legal name of a registered company that holds the account. Required if `type` is `corporate`."
     type: string
     example: Super Hero Masks Inc.
   tax_id:
-    title: TaxId
+    title: Tax ID
     description: The account holder's tax number/reference.
     type: string
     example: "123456"
   date_of_birth:
-    title: DateOfBirth
+    title: Date of birth
     description: The account holder's date of birth.
     allOf:
       - $ref: "#/components/schemas/DateOfBirth"
   country_of_birth:
-    title: CountryOfBirth
+    title: Country of birth
     description: The two-letter ISO country code of the account holder's country of birth.
     type: string
     format: ISO 3166-1
     example: "GB"
   residential_status:
-    title: ResidentalStatus
+    title: Residental status
     description: The two-letter ISO country code of the account holder's country of birth.
     type: string
     enum:
       - resident
       - non_resident
   billing_address:
-    title: BillingAddress
+    title: Billing address
     description: The billing address of the account holder.
     allOf:
       - $ref: "#/components/schemas/EntityAddress"
@@ -60,7 +60,7 @@ properties:
   identification:
     $ref: "#/components/schemas/MarketplaceAccountHolderIdentification"
   email:
-    title: email
+    title: Email
     description: The account holder's email address.
     type: string
     format: email

--- a/spec/components/schemas/Marketplace/Instruments/MarketplaceAccountHolderIdentification.yaml
+++ b/spec/components/schemas/Marketplace/Instruments/MarketplaceAccountHolderIdentification.yaml
@@ -1,10 +1,10 @@
 type: object
 title: AccountHolderIdentification
-description: Bank account holder's proof of identification
+description: Bank account holder's proof of identification.
 properties:
   type:
     title: Type
-    description: The type of identification used to identify the account holder
+    description: The type of identification used to identify the account holder.
     type: string
     enum:
       - passport
@@ -14,12 +14,12 @@ properties:
       - tax_id
   number:
     title: Number
-    description: The identification number
+    description: The identification number.
     type: string
     example: "09876"
   issuing_country:
     title: IssuingCountry
-    description: The two-letter ISO country code of the country that issued the identification
+    description: The two-letter ISO country code of the country that issued the identification.
     type: string
     format: ISO 3166-1
     example: "GB"

--- a/spec/components/schemas/Marketplace/Instruments/MarketplaceAccountHolderIdentification.yaml
+++ b/spec/components/schemas/Marketplace/Instruments/MarketplaceAccountHolderIdentification.yaml
@@ -1,5 +1,5 @@
 type: object
-title: AccountHolderIdentification
+title: Account holder identification
 description: Bank account holder's proof of identification.
 properties:
   type:

--- a/spec/components/schemas/Marketplace/Instruments/MarketplaceBank.yaml
+++ b/spec/components/schemas/Marketplace/Instruments/MarketplaceBank.yaml
@@ -3,16 +3,16 @@ title: Bank
 properties:
   name:
     title: Name
-    description: The bank's name
+    description: The bank's name.
     type: string
     example: Lloyds TSB
   branch:
     title: Branch
-    description: The bank branch's name
+    description: The bank branch's name.
     type: string
     example: London
   address:
     title: Address
-    description: The bank's contact address
+    description: The bank's contact address.
     allOf:
       - $ref: "#/components/schemas/EntityAddress"

--- a/spec/components/schemas/Marketplace/Instruments/MarketplaceInstrumentCreateRequest.yaml
+++ b/spec/components/schemas/Marketplace/Instruments/MarketplaceInstrumentCreateRequest.yaml
@@ -3,61 +3,61 @@ title: InstrumentCreateRequest
 properties:
   label:
     title: Label
-    description: A reference you can later use to identify this payment instrument
+    description: A reference you can later use to identify this payment instrument.
     type: string
     minLength: 1
     maxLength: 50
     example: Peter's Personal Account
   type:
     title: Type
-    description: The type of instrument
+    description: The type of instrument.
     type: string
     enum:
       - bank_account
   account_type:
-    title: AccountType
-    description: The type of account
+    title: Account type
+    description: The type of account.
     type: string
     enum:
       - savings
       - current
       - cash
   account_number:
-    title: AccountNumber
-    description: Number (which can contain letters) that identifies the account
+    title: Account number
+    description: Number (which can contain letters) that identifies the account.
     type: string
     example: "13654567455"
   bank_code:
-    title: BankCode
-    description: Code that identifies the bank
+    title: Bank code
+    description: Code that identifies the bank.
     type: string
     example: "123-456"
   branch_code:
-    title: BranchCode
-    description: Code that identifies the bank branch
+    title: Branch code
+    description: Code that identifies the bank branch.
     type: string
     example: "6443"
   iban:
     title: IBAN
-    description: Internationally agreed standard for identifying bank account
+    description: Internationally agreed standard for identifying bank account.
     type: string
     minLength: 5
     maxLength: 34
     example: "HU93116000060000000012345676"
   bban:
     title: BBAN
-    description: The combination of bank code and/or branch code and account number
+    description: The combination of bank code and/or branch code and account number.
     type: string
     example: "3704 0044 0532 0130 00"
   swift_bic:
     title: SwiftBic
-    description: 8 or 11 character code which identifies the bank or bank branch
+    description: An 8 or 11 character code that identifies the bank or bank branch.
     type: string
     format: ISO 9362:2009
     example: "37040044"
   currency:
     title: Currency
-    description: The three-letter ISO currency code of the account's currency
+    description: The three-letter ISO currency code of the account's currency.
     type: string
     format: ISO 4217
     minLength: 3
@@ -65,7 +65,7 @@ properties:
     example: "GBP"
   country:
     title: Country
-    description: The two-letter ISO country code of where the account is based
+    description: The two-letter ISO country code of where the account is based.
     type: string
     format: ISO 3166-1
     example: "GB"

--- a/spec/components/schemas/Marketplace/Instruments/MarketplaceInstrumentReference.yaml
+++ b/spec/components/schemas/Marketplace/Instruments/MarketplaceInstrumentReference.yaml
@@ -3,11 +3,11 @@ title: InstrumentReference
 properties:
   id:
     title: Id
-    description: The unique identifier of this payment instrument
+    description: The unique identifier of this payment instrument.
     type: string
     example: src_hmnkhxlshf3uhljow7zt7sf2cq
   label:
     title: Label
-    description: The reference you can use to identify this payment instrument
+    description: The reference you can use to identify this payment instrument.
     type: string
     example: Peter's Personal Account

--- a/spec/paths/marketplace@entities.yaml
+++ b/spec/paths/marketplace@entities.yaml
@@ -1,11 +1,11 @@
 post:
   description: |
-    Onboard a sub-entity, so they can start receiving payments. Upon creation, Checkout.com will run due diligence checks. 
-    If the checks are successful, the payment capabilities for the sub-entity will be enabled and they can start receiving payments.
+    Onboard a sub-entity so they can start receiving payments. Once created, Checkout.com will run due diligence checks. 
+    If the checks are successful, we'll enale payment capabilities for that sub-entity and they will start receiving payments.
   summary: Onboard a sub-entity
   requestBody:
     required: true
-    description: The sub-entity to be onboarded
+    description: The sub-entity to be onboarded.
     content:
       application/json:
         schema:

--- a/spec/paths/marketplace@entities.yaml
+++ b/spec/paths/marketplace@entities.yaml
@@ -1,7 +1,7 @@
 post:
   description: |
     Onboard a sub-entity so they can start receiving payments. Once created, Checkout.com will run due diligence checks. 
-    If the checks are successful, we'll enale payment capabilities for that sub-entity and they will start receiving payments.
+    If the checks are successful, we'll enable payment capabilities for that sub-entity and they will start receiving payments.
   summary: Onboard a sub-entity
   requestBody:
     required: true

--- a/spec/paths/marketplace@entities@{id}.yaml
+++ b/spec/paths/marketplace@entities@{id}.yaml
@@ -1,7 +1,7 @@
 parameters:
   - in: path
     name: id
-    description: The id of the sub-entity
+    description: The id of the sub-entity.
     required: true
     allowEmptyValue: false
     example: ent_w4jelhppmfiufdnatam37wrfc4
@@ -9,6 +9,7 @@ parameters:
     schema:
       type: string
 get:
+  description: Use this endpoint to retrieve a sub-entity and its full details.
   summary: Get sub-entity details
   security:
     - OAuth:
@@ -150,12 +151,12 @@ get:
     - Marketplace
 put:
   description: |
-    You can update all fields under the ContactDetails, Profile, and Company objects. 
+    You can update all fields under the Contact details, Profile, and Company objects. 
     Please note that when you update a sub-entity we may conduct further due diligence checks when necessary. During these checks, your payment capabilities will remain the same.
   summary: Update sub-entity details
   requestBody:
     required: true
-    description: The sub-entity to be updated
+    description: The sub-entity to be updated.
     content:
       application/json:
         schema:

--- a/spec/paths/marketplace@entities@{id}.yaml
+++ b/spec/paths/marketplace@entities@{id}.yaml
@@ -1,7 +1,8 @@
 parameters:
   - in: path
     name: id
-    description: The id of the sub-entity.
+    description: The ID of the sub-entity.
+
     required: true
     allowEmptyValue: false
     example: ent_w4jelhppmfiufdnatam37wrfc4

--- a/spec/paths/marketplace@entities@{id}@documents.yaml
+++ b/spec/paths/marketplace@entities@{id}@documents.yaml
@@ -1,7 +1,7 @@
 parameters:
   - in: path
     name: id
-    description: The id of the sub-entity.
+    description: The ID of the sub-entity.
     required: true
     allowEmptyValue: false
     example: ent_w4jelhppmfiufdnatam37wrfc4

--- a/spec/paths/marketplace@entities@{id}@documents.yaml
+++ b/spec/paths/marketplace@entities@{id}@documents.yaml
@@ -1,7 +1,7 @@
 parameters:
   - in: path
     name: id
-    description: The id of the sub-entity
+    description: The id of the sub-entity.
     required: true
     allowEmptyValue: false
     example: ent_w4jelhppmfiufdnatam37wrfc4
@@ -10,10 +10,10 @@ parameters:
       type: string
 post:
   description: Upload an identification document for your entity. If a document already exists for the entity, it will be replaced by the new document provided in this request.
-  summary: Upload a document (Individuals)
+  summary: Upload a document (individuals)
   requestBody:
     required: true
-    description: A multipart request outlining the document to be created. The document must have a document type, and can have a front and a back.
+    description: A multi-part request outlining the document to be created. The document must have a document type, and can have a front and a back.
     content:
       multipart/form-data:
         schema:

--- a/spec/paths/marketplace@entities@{id}@instruments.yaml
+++ b/spec/paths/marketplace@entities@{id}@instruments.yaml
@@ -1,7 +1,7 @@
 parameters:
   - in: path
     name: id
-    description: The id of the sub-entity.
+    description: The ID of the sub-entity.
     required: true
     allowEmptyValue: false
     example: ent_w4jelhppmfiufdnatam37wrfc4

--- a/spec/paths/marketplace@entities@{id}@instruments.yaml
+++ b/spec/paths/marketplace@entities@{id}@instruments.yaml
@@ -1,7 +1,7 @@
 parameters:
   - in: path
     name: id
-    description: The id of the sub-entity
+    description: The id of the sub-entity.
     required: true
     allowEmptyValue: false
     example: ent_w4jelhppmfiufdnatam37wrfc4
@@ -9,11 +9,11 @@ parameters:
     schema:
       type: string
 post:
-  description: Create a bank account payment instrument for your sub-entity that you can later use as the destination for their payouts
+  description: Create a bank account payment instrument for your sub-entity that you can later use as the destination for their payouts. 
   summary: Add a payment instrument
   requestBody:
     required: true
-    description: A json payload containing the payment instrument details
+    description: A JSON payload containing the payment instrument details.
     content:
       application/json:
         schema:

--- a/spec/paths/marketplace@entities@{id}@representatives@{representativeId}@documents.yaml
+++ b/spec/paths/marketplace@entities@{id}@representatives@{representativeId}@documents.yaml
@@ -1,7 +1,7 @@
 parameters:
   - in: path
     name: id
-    description: The id of the sub-entity.
+    description: The ID of the sub-entity.
     required: true
     allowEmptyValue: false
     example: ent_w4jelhppmfiufdnatam37wrfc4

--- a/spec/paths/marketplace@entities@{id}@representatives@{representativeId}@documents.yaml
+++ b/spec/paths/marketplace@entities@{id}@representatives@{representativeId}@documents.yaml
@@ -1,7 +1,7 @@
 parameters:
   - in: path
     name: id
-    description: The id of the sub-entity
+    description: The id of the sub-entity.
     required: true
     allowEmptyValue: false
     example: ent_w4jelhppmfiufdnatam37wrfc4
@@ -19,10 +19,10 @@ parameters:
       type: string
 post:
   description: Upload an identification document for your entity. If a document already exists for the entity, it will be replaced by the new document provided in this request.
-  summary: Upload a document (Representatives)
+  summary: Upload a document (representatives)
   requestBody:
     required: true
-    description: A multipart request outlining the document to be created. The document must have a document type, and can have a front and a back.
+    description: A multi-part request outlining the document to be created. The document must have a document type, and can have a front and a back.
     content:
       multipart/form-data:
         schema:


### PR DESCRIPTION
Mainly full stops added to schema descriptions.

'Title' property in schema seems to only decorative – according to JSON schema validation, so we prefer it if it wasn't camel case. I've changed it now – only a few applied (e.g. ContactDetails to Contact details). 