### PR TITLE
Removed slack and simulator action types

### DIFF
--- a/spec/components/schemas/Flow/workflows/actions/simulator-action.yaml
+++ b/spec/components/schemas/Flow/workflows/actions/simulator-action.yaml
@@ -3,7 +3,7 @@ description: Simulator action
 required:
   - url
 allOf:
-  - $ref: '#/components/schemas/workflow-action'
+  #- $ref: '#/components/schemas/workflow-action'
   - type: object
     required:
       - api_key

--- a/spec/components/schemas/Flow/workflows/actions/slack-action.yaml
+++ b/spec/components/schemas/Flow/workflows/actions/slack-action.yaml
@@ -3,7 +3,7 @@ description: Action that sends a Slack message
 required:
   - url
 allOf:
-  - $ref: '#/components/schemas/workflow-action'
+  #- $ref: '#/components/schemas/workflow-action'
   - type: object
     required:
       - url

--- a/spec/components/schemas/Flow/workflows/actions/workflow-action.yaml
+++ b/spec/components/schemas/Flow/workflows/actions/workflow-action.yaml
@@ -3,8 +3,8 @@ discriminator:
   propertyName: type
   mapping:
     webhook: '#/components/schemas/webhook-action'
-    simulator: '#/components/schemas/simulator-action'
-    slack: '#/components/schemas/slack-action'
+    #simulator: '#/components/schemas/simulator-action'
+    #slack: '#/components/schemas/slack-action'
 required: 
   - type
 properties:


### PR DESCRIPTION
Commented out the slack and simulator action types from the add a workflow endpoint so they're not visible