### PR TITLE
fix: update payment statuses to be Canceled

### DIFF
--- a/abc_spec/components/schemas/Events/Data.yaml
+++ b/abc_spec/components/schemas/Events/Data.yaml
@@ -35,7 +35,7 @@ properties:
       - Partially Refunded
       - Refunded
       - Declined
-      - Cancelled
+      - Canceled
     example: Authorized
   auth_code:
     type: string

--- a/abc_spec/components/schemas/Payments/Payment.yaml
+++ b/abc_spec/components/schemas/Payments/Payment.yaml
@@ -71,7 +71,7 @@ properties:
       - Partially Refunded
       - Refunded
       - Declined
-      - Cancelled
+      - Canceled
       - Paid
     example: Authorized
   3ds:

--- a/nas_spec/components/schemas/Events/Data.yaml
+++ b/nas_spec/components/schemas/Events/Data.yaml
@@ -35,7 +35,7 @@ properties:
       - Partially Refunded
       - Refunded
       - Declined
-      - Cancelled
+      - Canceled
     example: Authorized
   auth_code:
     type: string

--- a/nas_spec/components/schemas/Payments/Payment.yaml
+++ b/nas_spec/components/schemas/Payments/Payment.yaml
@@ -75,7 +75,7 @@ properties:
       - Partially Refunded
       - Refunded
       - Declined
-      - Cancelled
+      - Canceled
       - Paid
     example: Authorized
   balances:

--- a/nas_spec/components/schemas/Payments/PaymentDetails.yaml
+++ b/nas_spec/components/schemas/Payments/PaymentDetails.yaml
@@ -75,7 +75,7 @@ properties:
       - Partially Refunded
       - Refunded
       - Declined
-      - Cancelled
+      - Canceled
       - Paid
     example: Authorized
   balances:


### PR DESCRIPTION
Payment status for `Cancelled` is actually `Canceled` (US english)