### PR TITLE
Fix note about Mastercard only in incremental auths description

### DIFF
--- a/nas_spec/paths/payments@{id}@authorizations.yaml
+++ b/nas_spec/paths/payments@{id}@authorizations.yaml
@@ -8,7 +8,7 @@ post:
     - ApiSecretKey: []
   summary: Increment authorization
   description: |
-    Request an incremental authorization to increase the authorization amount or extend the authorization's validity period (Mastercard only).
+    Request an incremental authorization to increase the authorization amount or extend the authorization's validity period.
 
   parameters:
     - in: path


### PR DESCRIPTION
My fault: should have been part of https://github.com/checkout/checkout-api-reference/pull/382