### PR TITLE
Reorganise /paths into individual files

### DIFF
--- a/abc_spec/paths/customers.yaml
+++ b/abc_spec/paths/customers.yaml
@@ -1,29 +1,30 @@
-post:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Customers
-  summary: Create a customer
-  operationId: createCustomer
-  description: Create a customer which can be linked to one or more payment instruments, and can be passed as a source when making a payment, using the customer’s default instrument.
-  requestBody:
-    required: true
-    content:
-      application/json:
-        schema:
-          $ref: '#/components/schemas/CustomerCreateRequest'
-  responses:
-    '201':
-      description: Customer created successfully
+/customers:
+  post:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Customers
+    summary: Create a customer
+    operationId: createCustomer
+    description: Create a customer which can be linked to one or more payment instruments, and can be passed as a source when making a payment, using the customer’s default instrument.
+    requestBody:
+      required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/CustomerCreateResponse'
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
+            $ref: '#/components/schemas/CustomerCreateRequest'
+    responses:
+      '201':
+        description: Customer created successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CustomerCreateResponse'
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'

--- a/abc_spec/paths/customers@{identifier}.yaml
+++ b/abc_spec/paths/customers@{identifier}.yaml
@@ -1,105 +1,106 @@
-get:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Customers
-  summary: Get customer details
-  operationId: getCustomerDetails
-  description: Returns details of a customer and their instruments
-  parameters:
-    - in: path
-      name: identifier
-      required: true
-      description: The customer's ID or email
-      schema:
-        type: string
-        properties:
-          id:
-            type: string
-            pattern: "^(cus)_(\\w{26})$"
-          email:
-            type: string
-            format: email
-            maxLength: 255
-        additionalProperties: false
-        oneOf:
-          - required: [id]
-          - required: [email]
-  responses:
-    '200':
-      description: Customer retrieved successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/CustomerGetResponse'
-      headers:
-        Cko-Request-Id:
-          schema:
-            $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          schema:
-            $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Customer not found
-
-patch:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Customers
-  summary: Update customer details
-  operationId: updateCustomerDetails
-  description: Update details of a customer
-  parameters:
-    - in: path
-      name: identifier
-      schema:
-        type: string
-        pattern: "^(cus)_(\\w{26})$"
-      required: true
-      description: The customer id
-  requestBody:
-    required: true
-    content:
-      application/json:
+/customers/{identifier}:
+  get:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Customers
+    summary: Get customer details
+    operationId: getCustomerDetails
+    description: Returns details of a customer and their instruments
+    parameters:
+      - in: path
+        name: identifier
+        required: true
+        description: The customer's ID or email
         schema:
-          $ref: '#/components/schemas/UpdateCustomerRequest'
-  responses:
-    '204':
-      description: Customer updated successfully
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
+          type: string
+          properties:
+            id:
+              type: string
+              pattern: "^(cus)_(\\w{26})$"
+            email:
+              type: string
+              format: email
+              maxLength: 255
+          additionalProperties: false
+          oneOf:
+            - required: [id]
+            - required: [email]
+    responses:
+      '200':
+        description: Customer retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CustomerGetResponse'
+        headers:
+          Cko-Request-Id:
+            schema:
+              $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            schema:
+              $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Customer not found
+
+  patch:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Customers
+    summary: Update customer details
+    operationId: updateCustomerDetails
+    description: Update details of a customer
+    parameters:
+      - in: path
+        name: identifier
+        schema:
+          type: string
+          pattern: "^(cus)_(\\w{26})$"
+        required: true
+        description: The customer id
+    requestBody:
+      required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ValidationError'
-    '404':
-      description: Customer not found
+            $ref: '#/components/schemas/UpdateCustomerRequest'
+    responses:
+      '204':
+        description: Customer updated successfully
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '404':
+        description: Customer not found
 
-delete:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Customers
-  summary: Delete a customer
-  operationId: deleteCustomerDetails
-  description: Delete a customer and all of their linked payment instruments
-  parameters:
-    - in: path
-      name: identifier
-      required: true
-      schema:
-        type: string
-        pattern: "^(cus)_(\\w{26})$"
-      description: The customer id
-  responses:
-    '204':
-      description: Customer deleted successfully
-    '401':
-      description: Unauthorized
-    '404':
-      description: Customer not found or not associated with client
+  delete:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Customers
+    summary: Delete a customer
+    operationId: deleteCustomerDetails
+    description: Delete a customer and all of their linked payment instruments
+    parameters:
+      - in: path
+        name: identifier
+        required: true
+        schema:
+          type: string
+          pattern: "^(cus)_(\\w{26})$"
+        description: The customer id
+    responses:
+      '204':
+        description: Customer deleted successfully
+      '401':
+        description: Unauthorized
+      '404':
+        description: Customer not found or not associated with client

--- a/abc_spec/paths/disputes.yaml
+++ b/abc_spec/paths/disputes.yaml
@@ -1,95 +1,96 @@
-get:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Disputes
-  summary: Get disputes
-  operationId: getDisputes
-  description:
-    Returns a list of all disputes against your business. The results will be returned in reverse chronological order,
-    showing the last modified dispute (for example, where you've recently added a piece of evidence) first.
-    You can use the optional parameters below to skip or limit results.
-  parameters:
-    - in: query
-      name: limit
-      schema:
-        type: integer
-        minimum: 1
-        maximum: 250
-        default: 50
-      required: false
-      description: The numbers of results to return
-    - in: query
-      name: skip
-      schema:
-        type: integer
-        minimum: 0
-        default: 0
-      required: false
-      description: The number of results to skip
-    - in: query
-      name: from
-      schema:
-        type: string
-        format: ISO-8601
-      required: false
-      description: The date and time from which to filter disputes, based on the dispute's `last_update` field
-    - in: query
-      name: to
-      schema:
-        type: string
-        format: ISO-8601
-      required: false
-      description: The date and time until which to filter disputes, based on the dispute's `last_update` field
-    - in: query
-      name: id
-      schema:
-        type: string
-      required: false
-      description: The unique identifier of the dispute
-    - in: query
-      name: statuses
-      schema:
-        type: string
-        example: evidence_required,evidence_under_review
-      required: false
-      description: One or more comma-separated statuses. This works like a logical *OR* operator
-    - in: query
-      name: payment_id
-      schema:
-        type: string
-      required: false
-      description: The unique identifier of the payment
-    - in: query
-      name: payment_reference
-      schema:
-        type: string
-      required: false
-      description: An optional reference (such as an order ID) that you can use later to identify the payment. Previously known as `TrackId`
-    - in: query
-      name: payment_arn
-      schema:
-        type: string
-      required: false
-      description: The acquirer reference number (ARN) that you can use to query the issuing bank
-    - in: query
-      name: this_channel_only
-      schema:
-        type: boolean
-      required: false
-      description: If `true`, only returns disputes of the specific channel that the secret key is associated with. Otherwise, returns all disputes for that business
-  responses:
-    '200':
-      description: Disputes retrieved successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/DisputePaged'
-    '401':
-      description: Unauthorized
-    '422':
-      description: Unprocessable paging
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/PagingError'
+/disputes:
+  get:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Disputes
+    summary: Get disputes
+    operationId: getDisputes
+    description:
+      Returns a list of all disputes against your business. The results will be returned in reverse chronological order,
+      showing the last modified dispute (for example, where you've recently added a piece of evidence) first.
+      You can use the optional parameters below to skip or limit results.
+    parameters:
+      - in: query
+        name: limit
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 250
+          default: 50
+        required: false
+        description: The numbers of results to return
+      - in: query
+        name: skip
+        schema:
+          type: integer
+          minimum: 0
+          default: 0
+        required: false
+        description: The number of results to skip
+      - in: query
+        name: from
+        schema:
+          type: string
+          format: ISO-8601
+        required: false
+        description: The date and time from which to filter disputes, based on the dispute's `last_update` field
+      - in: query
+        name: to
+        schema:
+          type: string
+          format: ISO-8601
+        required: false
+        description: The date and time until which to filter disputes, based on the dispute's `last_update` field
+      - in: query
+        name: id
+        schema:
+          type: string
+        required: false
+        description: The unique identifier of the dispute
+      - in: query
+        name: statuses
+        schema:
+          type: string
+          example: evidence_required,evidence_under_review
+        required: false
+        description: One or more comma-separated statuses. This works like a logical *OR* operator
+      - in: query
+        name: payment_id
+        schema:
+          type: string
+        required: false
+        description: The unique identifier of the payment
+      - in: query
+        name: payment_reference
+        schema:
+          type: string
+        required: false
+        description: An optional reference (such as an order ID) that you can use later to identify the payment. Previously known as `TrackId`
+      - in: query
+        name: payment_arn
+        schema:
+          type: string
+        required: false
+        description: The acquirer reference number (ARN) that you can use to query the issuing bank
+      - in: query
+        name: this_channel_only
+        schema:
+          type: boolean
+        required: false
+        description: If `true`, only returns disputes of the specific channel that the secret key is associated with. Otherwise, returns all disputes for that business
+    responses:
+      '200':
+        description: Disputes retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DisputePaged'
+      '401':
+        description: Unauthorized
+      '422':
+        description: Unprocessable paging
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PagingError'

--- a/abc_spec/paths/disputes@{dispute_id}.yaml
+++ b/abc_spec/paths/disputes@{dispute_id}.yaml
@@ -1,27 +1,28 @@
-get:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Disputes
-  summary: Get dispute details
-  operationId: getDisputeDetails
-  description: Returns all the details of a dispute using the dispute identifier.
-  parameters:
-    - in: path
-      name: dispute_id
-      schema:
-        type: string
-        pattern: "^(dsp)_(\\w{26})$"
-      required: true
-      description: The dispute identifier
-  responses:
-    '200':
-      description: Dispute retrieved successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Dispute'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Dispute not found
+/disputes/{dispute_id}:
+  get:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Disputes
+    summary: Get dispute details
+    operationId: getDisputeDetails
+    description: Returns all the details of a dispute using the dispute identifier.
+    parameters:
+      - in: path
+        name: dispute_id
+        schema:
+          type: string
+          pattern: "^(dsp)_(\\w{26})$"
+        required: true
+        description: The dispute identifier
+    responses:
+      '200':
+        description: Dispute retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Dispute'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Dispute not found

--- a/abc_spec/paths/disputes@{dispute_id}@accept.yaml
+++ b/abc_spec/paths/disputes@{dispute_id}@accept.yaml
@@ -1,23 +1,24 @@
-post:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Disputes
-  summary: Accept dispute
-  operationId: acceptDispute
-  description: If a dispute is legitimate, you can choose to accept it. This will close it for you and remove it from your list of open disputes. There are no further financial implications.
-  parameters:
-    - in: path
-      name: dispute_id
-      schema:
-        type: string
-        pattern: "^(dsp)_(\\w{26})$"
-      required: true
-      description: The dispute identifier
-  responses:
-    '204':
-      description: Dispute accepted successfully
-    '401':
-      description: Unauthorized
-    '404':
-      description: Dispute not found
+/disputes/{dispute_id}/accept:
+  post:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Disputes
+    summary: Accept dispute
+    operationId: acceptDispute
+    description: If a dispute is legitimate, you can choose to accept it. This will close it for you and remove it from your list of open disputes. There are no further financial implications.
+    parameters:
+      - in: path
+        name: dispute_id
+        schema:
+          type: string
+          pattern: "^(dsp)_(\\w{26})$"
+        required: true
+        description: The dispute identifier
+    responses:
+      '204':
+        description: Dispute accepted successfully
+      '401':
+        description: Unauthorized
+      '404':
+        description: Dispute not found

--- a/abc_spec/paths/disputes@{dispute_id}@evidence.yaml
+++ b/abc_spec/paths/disputes@{dispute_id}@evidence.yaml
@@ -1,91 +1,92 @@
-put:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Disputes
-  summary: Provide dispute evidence
-  operationId: provideDisputeEvidence
-  description: |
-    Adds supporting evidence to a dispute. Before using this endpoint, you first need to [upload your files](#tag/Disputes/paths/~1files/post) using the file uploader. You will receive a file id (prefixed by `file_`) which you can then use in your request.
-    Note that this only attaches the evidence to the dispute, it does not send it to us. Once ready, you will need to submit it.
+/disputes/{dispute_id}/evidence:
+  put:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Disputes
+    summary: Provide dispute evidence
+    operationId: provideDisputeEvidence
+    description: |
+      Adds supporting evidence to a dispute. Before using this endpoint, you first need to [upload your files](#tag/Disputes/paths/~1files/post) using the file uploader. You will receive a file id (prefixed by `file_`) which you can then use in your request.
+      Note that this only attaches the evidence to the dispute, it does not send it to us. Once ready, you will need to submit it.
 
-    **You must provide at least one evidence type in the body of your request.**
-  parameters:
-    - in: path
-      name: dispute_id
-      schema:
-        type: string
-        pattern: "^(dsp)_(\\w{26})$"
-      required: true
-      description: The dispute identifier
-  requestBody:
-    content:
-      application/json:
+      **You must provide at least one evidence type in the body of your request.**
+    parameters:
+      - in: path
+        name: dispute_id
         schema:
-          $ref: '#/components/schemas/ProvideEvidenceRequest'
-  responses:
-    '204':
-      description: Dispute evidence provided successfully
-    '400':
-      description: Unprocessable
-    '401':
-      description: Unauthorized
-    '404':
-      description: Dispute not found
-    '422':
-      description: Unprocessable entity
-
-get:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Disputes
-  summary: Get dispute evidence
-  operationId: getDisputeEvidence
-  description: |
-    Retrieves a list of the evidence submitted in response to a specific dispute.
-  parameters:
-    - in: path
-      name: dispute_id
-      schema:
-        type: string
-        pattern: "^(dsp)_(\\w{26})$"
-      required: true
-      description: The dispute identifier
-  responses:
-    '200':
-      description: Dispute evidence retrieved successfully
+          type: string
+          pattern: "^(dsp)_(\\w{26})$"
+        required: true
+        description: The dispute identifier
+    requestBody:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Evidence'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Dispute not found
+            $ref: '#/components/schemas/ProvideEvidenceRequest'
+    responses:
+      '204':
+        description: Dispute evidence provided successfully
+      '400':
+        description: Unprocessable
+      '401':
+        description: Unauthorized
+      '404':
+        description: Dispute not found
+      '422':
+        description: Unprocessable entity
 
-post:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Disputes
-  summary: Submit dispute evidence
-  operationId: submitDisputeEvidence
-  description:
-    With this final request, you can submit the evidence that you have previously provided. Make sure you have provided all the relevant information before using this request.
-    You will not be able to amend your evidence once you have submitted it.
-  parameters:
-    - in: path
-      name: dispute_id
-      schema:
-        type: string
-        pattern: "^(dsp)_(\\w{26})$"
-      required: true
-      description: The dispute identifier
-  responses:
-    '204':
-      description: Dispute evidence submitted successfully
-    '401':
-      description: Unauthorized
-    '404':
-      description: Dispute not found
+  get:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Disputes
+    summary: Get dispute evidence
+    operationId: getDisputeEvidence
+    description: |
+      Retrieves a list of the evidence submitted in response to a specific dispute.
+    parameters:
+      - in: path
+        name: dispute_id
+        schema:
+          type: string
+          pattern: "^(dsp)_(\\w{26})$"
+        required: true
+        description: The dispute identifier
+    responses:
+      '200':
+        description: Dispute evidence retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Evidence'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Dispute not found
+
+  post:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Disputes
+    summary: Submit dispute evidence
+    operationId: submitDisputeEvidence
+    description:
+      With this final request, you can submit the evidence that you have previously provided. Make sure you have provided all the relevant information before using this request.
+      You will not be able to amend your evidence once you have submitted it.
+    parameters:
+      - in: path
+        name: dispute_id
+        schema:
+          type: string
+          pattern: "^(dsp)_(\\w{26})$"
+        required: true
+        description: The dispute identifier
+    responses:
+      '204':
+        description: Dispute evidence submitted successfully
+      '401':
+        description: Unauthorized
+      '404':
+        description: Dispute not found

--- a/abc_spec/paths/event-types.yaml
+++ b/abc_spec/paths/event-types.yaml
@@ -1,33 +1,34 @@
-get:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Events
-  summary: Retrieve event types
-  operationId: retrieveEventTypes
-  description: Retrieve a list of event types grouped by their respective version that you can configure on your webhooks.
-  parameters:
-    - in: query
-      name: version
-      schema:
-        type: string
-      description: The API version for which you want to retrieve the event types. Set this to `1.0` for the legacy API or `2.0` for the Unified Payments API. If no version is specified, event types for both versions will be returned.
-      required: false
-  responses:
-    '200':
-      description: Event types retrieved successfully
-      content:
-        application/json:
-          schema:
-            type: array
-            items:
-              $ref: '#/components/schemas/EventTypesObject'
-      headers:
-        Cko-Request-Id:
-          schema:
-            $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          schema:
-            $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
+/event-types:
+  get:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Events
+    summary: Retrieve event types
+    operationId: retrieveEventTypes
+    description: Retrieve a list of event types grouped by their respective version that you can configure on your webhooks.
+    parameters:
+      - in: query
+        name: version
+        schema:
+          type: string
+        description: The API version for which you want to retrieve the event types. Set this to `1.0` for the legacy API or `2.0` for the Unified Payments API. If no version is specified, event types for both versions will be returned.
+        required: false
+    responses:
+      '200':
+        description: Event types retrieved successfully
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/EventTypesObject'
+        headers:
+          Cko-Request-Id:
+            schema:
+              $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            schema:
+              $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized

--- a/abc_spec/paths/events.yaml
+++ b/abc_spec/paths/events.yaml
@@ -1,88 +1,89 @@
-get:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Events
-  summary: Retrieve events
-  operationId: retrieveEvents
-  description: |
-    Retrieves events based on your query parameters.
-  parameters:
-    - in: query
-      name: payment_id
-      schema:
-        type: string
-        pattern: "^(pay)_(\\w{26})$"
-        description: The identifier of a payment
-        example: pay_ok2ynq6ubn3ufmo6jsdfmdvy5q
-    - in: query
-      name: charge_id
-      schema:
-        type: string
-        pattern: "^(charge|charge_test)_(\\w{20})$"
-        description: The identifier of a charge
-        example: charge_FC1919EE547L23CC6BE1
-    - in: query
-      name: track_id
-      schema:
-        type: string
-        description: The tracking ID of a payment
-        example: TRK12345
-    - in: query
-      name: reference
-      schema:
-        type: string
-        description: The reference of a payment
-        example: ORD-5023-4E89
-    - in: query
-      name: skip
-      schema:
-        type: integer
-        description: Set how many events you want to skip
-        example: 0
-    - in: query
-      name: limit
-      schema:
-        type: integer
-        description: Limit how many events your request returns
-        example: 5
-    - in: query
-      name: from
-      schema:
-        type: string
-        format: date-time
-        description: Set the date and time from which you want to retrieve events
-        example: "2020-11-07T04:00:00Z"
-    - in: query
-      name: to
-      schema:
-        type: string
-        format: date-time
-        description: Set the date and time to which you want to retrieve events
-        example: "2020-11-07T08:15:00Z"
-  responses:
-    '200':
-      description: OK
-      content:
-        application/json:
-          schema:
-            oneOf:
-              - $ref: '#/components/schemas/Payment_Id'
-              - $ref: '#/components/schemas/Charge_Id'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '204':
-      description: No Content
-    '401':
-      description: Unauthorized
-    '422':
-      description: Unprocessable Entry
-      content:
-        application/json:
-          schema:
-            oneOf:
-              - $ref: '#/components/schemas/PaymentIdInvalidResponse'
-              - $ref: '#/components/schemas/ChargeIdInvalidResponse'
+/events:
+  get:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Events
+    summary: Retrieve events
+    operationId: retrieveEvents
+    description: |
+      Retrieves events based on your query parameters.
+    parameters:
+      - in: query
+        name: payment_id
+        schema:
+          type: string
+          pattern: "^(pay)_(\\w{26})$"
+          description: The identifier of a payment
+          example: pay_ok2ynq6ubn3ufmo6jsdfmdvy5q
+      - in: query
+        name: charge_id
+        schema:
+          type: string
+          pattern: "^(charge|charge_test)_(\\w{20})$"
+          description: The identifier of a charge
+          example: charge_FC1919EE547L23CC6BE1
+      - in: query
+        name: track_id
+        schema:
+          type: string
+          description: The tracking ID of a payment
+          example: TRK12345
+      - in: query
+        name: reference
+        schema:
+          type: string
+          description: The reference of a payment
+          example: ORD-5023-4E89
+      - in: query
+        name: skip
+        schema:
+          type: integer
+          description: Set how many events you want to skip
+          example: 0
+      - in: query
+        name: limit
+        schema:
+          type: integer
+          description: Limit how many events your request returns
+          example: 5
+      - in: query
+        name: from
+        schema:
+          type: string
+          format: date-time
+          description: Set the date and time from which you want to retrieve events
+          example: "2020-11-07T04:00:00Z"
+      - in: query
+        name: to
+        schema:
+          type: string
+          format: date-time
+          description: Set the date and time to which you want to retrieve events
+          example: "2020-11-07T08:15:00Z"
+    responses:
+      '200':
+        description: OK
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/Payment_Id'
+                - $ref: '#/components/schemas/Charge_Id'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '204':
+        description: No Content
+      '401':
+        description: Unauthorized
+      '422':
+        description: Unprocessable Entry
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/PaymentIdInvalidResponse'
+                - $ref: '#/components/schemas/ChargeIdInvalidResponse'

--- a/abc_spec/paths/events@{eventId}.yaml
+++ b/abc_spec/paths/events@{eventId}.yaml
@@ -1,33 +1,34 @@
-get:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Events
-  summary: Retrieve event
-  operationId: retrieveEvent
-  description: |
-    Retrieves the event with the specified identifier string. The event `data` includes the full event details, the schema of which will vary based on the `type`.
-  parameters:
-    - in: path
-      name: eventId
-      schema:
-        type: string
-        pattern: "^(evt)_(\\w{26})$"
-      required: true
-      description: The event identifier
-  responses:
-    '200':
-      description: Event retrieved successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/EventObject'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Event not found
+/events/{eventId}:
+  get:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Events
+    summary: Retrieve event
+    operationId: retrieveEvent
+    description: |
+      Retrieves the event with the specified identifier string. The event `data` includes the full event details, the schema of which will vary based on the `type`.
+    parameters:
+      - in: path
+        name: eventId
+        schema:
+          type: string
+          pattern: "^(evt)_(\\w{26})$"
+        required: true
+        description: The event identifier
+    responses:
+      '200':
+        description: Event retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EventObject'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Event not found

--- a/abc_spec/paths/events@{eventId}@notifications@{notificationId}.yaml
+++ b/abc_spec/paths/events@{eventId}@notifications@{notificationId}.yaml
@@ -1,39 +1,40 @@
-get:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Events
-  summary: Retrieve event notification
-  operationId: retrieveEventNotification
-  description: Retrieves the attempts for a specific event notification
-  parameters:
-    - in: path
-      name: eventId
-      schema:
-        type: string
-        pattern: "^(evt)_(\\w{26})$"
-      required: true
-      description: The event identifier
-    - in: path
-      name: notificationId
-      schema:
-        type: string
-        pattern: "^(ntf)_(\\w{26})$"
-      required: true
-      description: The notification identifier
-  responses:
-    '200':
-      description: Notification retrieved successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Notification'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Event or notification not found
+/events/{eventId}/notifications/{notificationId}:
+  get:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Events
+    summary: Retrieve event notification
+    operationId: retrieveEventNotification
+    description: Retrieves the attempts for a specific event notification
+    parameters:
+      - in: path
+        name: eventId
+        schema:
+          type: string
+          pattern: "^(evt)_(\\w{26})$"
+        required: true
+        description: The event identifier
+      - in: path
+        name: notificationId
+        schema:
+          type: string
+          pattern: "^(ntf)_(\\w{26})$"
+        required: true
+        description: The notification identifier
+    responses:
+      '200':
+        description: Notification retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Notification'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Event or notification not found

--- a/abc_spec/paths/events@{eventId}@webhooks@retry.yaml
+++ b/abc_spec/paths/events@{eventId}@webhooks@retry.yaml
@@ -1,28 +1,29 @@
-post:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Events
-  summary: Retry all webhooks
-  operationId: retryAllWebhooks
-  description: Retries all webhook notifications configured for the specified event
-  parameters:
-    - in: path
-      name: eventId
-      schema:
-        type: string
-        pattern: "^(evt)_(\\w{26})$"
-      required: true
-      description: The event identifier
-  responses:
-    '202':
-      description: Retry accepted
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Event or webhook not found
+/events/{eventId}/webhooks/retry:
+  post:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Events
+    summary: Retry all webhooks
+    operationId: retryAllWebhooks
+    description: Retries all webhook notifications configured for the specified event
+    parameters:
+      - in: path
+        name: eventId
+        schema:
+          type: string
+          pattern: "^(evt)_(\\w{26})$"
+        required: true
+        description: The event identifier
+    responses:
+      '202':
+        description: Retry accepted
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Event or webhook not found

--- a/abc_spec/paths/events@{eventId}@webhooks@{webhookId}@retry.yaml
+++ b/abc_spec/paths/events@{eventId}@webhooks@{webhookId}@retry.yaml
@@ -1,36 +1,37 @@
-post:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Events
-  summary: Retry webhook
-  operationId: retryWebhook
-  description: Retries a specific webhook notification for the given event
-  parameters:
-    - in: path
-      name: eventId
-      schema:
-        type: string
-        pattern: "^(evt)_(\\w{26})$"
-      required: true
-      description: The event identifier
-    - in: path
-      name: webhookId
-      schema:
-        type: string
-        pattern: "^(wh)_(\\w{32})$"
-      required: true
-      description: The webhook identifier
-      example: 'wh_387ac7a83a054e37ae140105429d76b5'
-  responses:
-    '202':
-      description: Retry accepted
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Event or webhook not found
+/events/{eventId}/webhooks/{webhookId}/retry:
+  post:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Events
+    summary: Retry webhook
+    operationId: retryWebhook
+    description: Retries a specific webhook notification for the given event
+    parameters:
+      - in: path
+        name: eventId
+        schema:
+          type: string
+          pattern: "^(evt)_(\\w{26})$"
+        required: true
+        description: The event identifier
+      - in: path
+        name: webhookId
+        schema:
+          type: string
+          pattern: "^(wh)_(\\w{32})$"
+        required: true
+        description: The webhook identifier
+        example: 'wh_387ac7a83a054e37ae140105429d76b5'
+    responses:
+      '202':
+        description: Retry accepted
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Event or webhook not found

--- a/abc_spec/paths/files.yaml
+++ b/abc_spec/paths/files.yaml
@@ -1,31 +1,32 @@
-post:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Disputes
-  summary: Upload file
-  operationId: uploadFile
-  description: Upload a file to use as evidence in a dispute. Your file must be in either JPEG/JPG, PNG or PDF format, and be no larger than 4MB.
-  requestBody:
-    content:
-      multipart/form-data:
-        schema:
-          $ref: '#/components/schemas/File'
-  responses:
-    '200':
-      description: File uploaded successfully
+/files:
+  post:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Disputes
+    summary: Upload file
+    operationId: uploadFile
+    description: Upload a file to use as evidence in a dispute. Your file must be in either JPEG/JPG, PNG or PDF format, and be no larger than 4MB.
+    requestBody:
       content:
-        application/json:
+        multipart/form-data:
           schema:
-            $ref: '#/components/schemas/FileUploadResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '422':
-      description: Unprocessable
-    '429':
-      description: Too many requests
+            $ref: '#/components/schemas/File'
+    responses:
+      '200':
+        description: File uploaded successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FileUploadResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '422':
+        description: Unprocessable
+      '429':
+        description: Too many requests

--- a/abc_spec/paths/files@{file_id}.yaml
+++ b/abc_spec/paths/files@{file_id}.yaml
@@ -1,33 +1,34 @@
-get:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Disputes
-  summary: Get file information
-  operationId: getFileInformation
-  description: Retrieve information about a file that was previously uploaded.
-  parameters:
-    - in: path
-      name: file_id
-      schema:
-        type: string
-      required: true
-      description: The file identifier. It is always prefixed by `file_`.
-  responses:
-    '200':
-      description: File information retrieved successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/FileResult'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: File not found
-    '429':
-      description: Too many requests or duplicate request detected
+/files/{file_id}:
+  get:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Disputes
+    summary: Get file information
+    operationId: getFileInformation
+    description: Retrieve information about a file that was previously uploaded.
+    parameters:
+      - in: path
+        name: file_id
+        schema:
+          type: string
+        required: true
+        description: The file identifier. It is always prefixed by `file_`.
+    responses:
+      '200':
+        description: File information retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FileResult'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: File not found
+      '429':
+        description: Too many requests or duplicate request detected

--- a/abc_spec/paths/hosted-payments.yaml
+++ b/abc_spec/paths/hosted-payments.yaml
@@ -1,32 +1,33 @@
-post:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Hosted Payments Page
-  summary: Create a Hosted Payments Page session
-  operationId: createAHostedPaymentsSession
-  description: |
-    Create a Hosted Payments Page session and pass through all the payment information, like the amount, currency, country and reference.
+/hosted-payments:
+  post:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Hosted Payments Page
+    summary: Create a Hosted Payments Page session
+    operationId: createAHostedPaymentsSession
+    description: |
+      Create a Hosted Payments Page session and pass through all the payment information, like the amount, currency, country and reference.
 
-    To get started with our Hosted Payments Page, contact your Solutions Engineer or integration@checkout.com.
-  requestBody:
-    required: true
-    content:
-      application/json:
-        schema:
-          $ref: '#/components/schemas/HostedPaymentsRequest'
-  responses:
-    '201':
-      description: Created Hosted Payments Page
+      To get started with our Hosted Payments Page, contact your Solutions Engineer or integration@checkout.com.
+    requestBody:
+      required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/HostedPaymentsResponse'
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
+            $ref: '#/components/schemas/HostedPaymentsRequest'
+    responses:
+      '201':
+        description: Created Hosted Payments Page
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HostedPaymentsResponse'
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'

--- a/abc_spec/paths/instruments.yaml
+++ b/abc_spec/paths/instruments.yaml
@@ -1,30 +1,31 @@
-post:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Instruments
-  summary: Create an instrument
-  operationId: createAnInstrument
-  description: |
-    Exchange a single use Checkout.com token for a payment instrument reference, that can be used at any time to request one or more payments.
-  requestBody:
-    required: true
-    content:
-      application/json:
-        schema:
-          $ref: '#/components/schemas/InstrumentRequest'
-  responses:
-    '201':
-      description: Instrument created successfully
+/instruments:
+  post:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Instruments
+    summary: Create an instrument
+    operationId: createAnInstrument
+    description: |
+      Exchange a single use Checkout.com token for a payment instrument reference, that can be used at any time to request one or more payments.
+    requestBody:
+      required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/InstrumentResponse'
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
+            $ref: '#/components/schemas/InstrumentRequest'
+    responses:
+      '201':
+        description: Instrument created successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InstrumentResponse'
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'

--- a/abc_spec/paths/instruments@{id}.yaml
+++ b/abc_spec/paths/instruments@{id}.yaml
@@ -1,103 +1,104 @@
-get:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Instruments
-  summary: Get instrument details
-  operationId: getInstrumentDetails
-  description: Returns details of an instrument
-  parameters:
-    - in: path
-      name: id
-      schema:
-        type: string
-        pattern: "^(src)_(\\w{26})$"
-      required: true
-      description: The instrument id
-  responses:
-    '200':
-      description: Instrument retrieved successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/RetrieveInstrumentResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Instrument not found
-
-patch:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Instruments
-  summary: Update instrument details
-  operationId: updateInstrumentDetails
-  description: Update details of an instrument
-  parameters:
-    - in: path
-      name: id
-      schema:
-        type: string
-        pattern: "^(src)_(\\w{26})$"
-        example: src_ubfj2q76miwundwlk72vxt2i7q
-      required: true
-      description: The instrument ID
-  requestBody:
-    required: true
-    content:
-      application/json:
+/instruments/{id}:
+  get:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Instruments
+    summary: Get instrument details
+    operationId: getInstrumentDetails
+    description: Returns details of an instrument
+    parameters:
+      - in: path
+        name: id
         schema:
-          $ref: '#/components/schemas/UpdateInstrumentRequest'
-  responses:
-    '200':
-      description: Instrument updated successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/UpdateInstrumentResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '404':
-      description: Instrument not found
+          type: string
+          pattern: "^(src)_(\\w{26})$"
+        required: true
+        description: The instrument id
+    responses:
+      '200':
+        description: Instrument retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RetrieveInstrumentResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Instrument not found
 
-delete:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Instruments
-  summary: Delete an instrument
-  operationId: removeInstrument
-  description: Delete a payment instrument.
-  parameters:
-    - in: path
-      name: id
-      schema:
-        type: string
-        pattern: "^(src)_(\\w{26})$"
-        example: src_ubfj2q76miwundwlk72vxt2i7q
+  patch:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Instruments
+    summary: Update instrument details
+    operationId: updateInstrumentDetails
+    description: Update details of an instrument
+    parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          pattern: "^(src)_(\\w{26})$"
+          example: src_ubfj2q76miwundwlk72vxt2i7q
+        required: true
+        description: The instrument ID
+    requestBody:
       required: true
-      description: The payment instrument to be deleted
-  responses:
-    '204':
-      description: Instrument deleted successfully
-    '401':
-      description: Unauthorized
-    '404':
-      description: Instrument not found or not associated with client
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UpdateInstrumentRequest'
+    responses:
+      '200':
+        description: Instrument updated successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateInstrumentResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '404':
+        description: Instrument not found
+
+  delete:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Instruments
+    summary: Delete an instrument
+    operationId: removeInstrument
+    description: Delete a payment instrument.
+    parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          pattern: "^(src)_(\\w{26})$"
+          example: src_ubfj2q76miwundwlk72vxt2i7q
+        required: true
+        description: The payment instrument to be deleted
+    responses:
+      '204':
+        description: Instrument deleted successfully
+      '401':
+        description: Unauthorized
+      '404':
+        description: Instrument not found or not associated with client

--- a/abc_spec/paths/payment-links.yaml
+++ b/abc_spec/paths/payment-links.yaml
@@ -1,30 +1,31 @@
-post:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Payment Links
-  summary: Create a Payment Link
-  operationId: createAPaymentLinkSession
-  description: |
-    Create a Payment Link and pass through all the payment information, like the amount, currency, country and reference.
-  requestBody:
-    required: true
-    content:
-      application/json:
-        schema:
-          $ref: '#/components/schemas/PaymentLinksRequest'
-  responses:
-    '201':
-      description: Create Payment Link Page
+/payment-links:
+  post:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Payment Links
+    summary: Create a Payment Link
+    operationId: createAPaymentLinkSession
+    description: |
+      Create a Payment Link and pass through all the payment information, like the amount, currency, country and reference.
+    requestBody:
+      required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/PaymentLinksResponse'
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
+            $ref: '#/components/schemas/PaymentLinksRequest'
+    responses:
+      '201':
+        description: Create Payment Link Page
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PaymentLinksResponse'
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'

--- a/abc_spec/paths/payment-links@{id}.yaml
+++ b/abc_spec/paths/payment-links@{id}.yaml
@@ -1,35 +1,36 @@
-get:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Payment Links
-  summary: Get Payment Link details
-  operationId: getPaymentLinkDetails
-  description: |
-    Retrieve details about a specific Payment Link using its ID returned when the link was created. In the response, you will see the status of the Payment Link.<br> <br>For more information, see the <a target="_blank" href="https://docs.checkout.com/integrate/payment-links">Payment Links documentation</a>.
-  parameters:
-    - in: path
-      name: id
-      required: true
-      schema:
-        allOf:
-          - $ref: '#/components/schemas/PaymentLinkId'
-        minLength: 15
-        maxLength: 15
-      description: The Payment Link ID.
-  responses:
-    '200':
-      description: Payment Link details retrieved successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/GetPaymentLinkResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Payment Link session not found
+/payment-links/{id}:
+  get:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Payment Links
+    summary: Get Payment Link details
+    operationId: getPaymentLinkDetails
+    description: |
+      Retrieve details about a specific Payment Link using its ID returned when the link was created. In the response, you will see the status of the Payment Link.<br> <br>For more information, see the <a target="_blank" href="https://docs.checkout.com/integrate/payment-links">Payment Links documentation</a>.
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          allOf:
+            - $ref: '#/components/schemas/PaymentLinkId'
+          minLength: 15
+          maxLength: 15
+        description: The Payment Link ID.
+    responses:
+      '200':
+        description: Payment Link details retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetPaymentLinkResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Payment Link session not found

--- a/abc_spec/paths/payments.yaml
+++ b/abc_spec/paths/payments.yaml
@@ -1,163 +1,164 @@
-post:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Payments
-  summary: Request a payment or payout
-  operationId: requestAPaymentOrPayout
-  description: |
-    To accept payments from <a href="https://docs.checkout.com/payment-methods/cards" target="blank">cards</a>, <a href="https://docs.checkout.com/payment-methods/wallets" target="blank">digital wallets</a> and many <a href="https://docs.checkout.com/payment-methods/" target="blank">alternative payment methods</a>, specify the `source.type` field, along with the source-specific data.
+/payments:
+  post:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Payments
+    summary: Request a payment or payout
+    operationId: requestAPaymentOrPayout
+    description: |
+      To accept payments from <a href="https://docs.checkout.com/payment-methods/cards" target="blank">cards</a>, <a href="https://docs.checkout.com/payment-methods/wallets" target="blank">digital wallets</a> and many <a href="https://docs.checkout.com/payment-methods/" target="blank">alternative payment methods</a>, specify the `source.type` field, along with the source-specific data.
 
-    To <a href="https://docs.checkout.com/payment-actions/card-payouts" target="blank">pay out to a card</a>, specify the destination of your payout using the `destination.type` field, along with the destination-specific data.
+      To <a href="https://docs.checkout.com/payment-actions/card-payouts" target="blank">pay out to a card</a>, specify the destination of your payout using the `destination.type` field, along with the destination-specific data.
 
-    To verify the success of the payment, check the `approved` field in the response.
-  parameters:
-    - $ref: '#/components/parameters/ckoIdempotencyKey'
-  requestBody:
-    content:
-      application/json:
-        schema:
-          oneOf:
-            - $ref: '#/components/schemas/PaymentRequest'
-            - $ref: '#/components/schemas/Payout'
-        example:
-          source:
-            type: token
-            token: tok_4gzeau5o2uqubbk6fufs3m7p54
-          amount: 6540
-          currency: USD
-          payment_type: Recurring
-          reference: 'ORD-5023-4E89'
-          description: 'Set of 3 masks'
-          capture: true
-          capture_on: '2019-09-10T10:11:12Z'
-          customer:
-            id: 'cus_udst2tfldj6upmye2reztkmm4i'
-            email: 'brucewayne@gmail.com'
-            name: 'Bruce Wayne'
-          billing_descriptor:
-            name: SUPERHEROES.COM
-            city: GOTHAM
-          shipping:
-            address:
-              address_line1: Checkout.com
-              address_line2: 90 Tottenham Court Road
-              city: London
-              state: London
-              zip: W1T 4TJ
-              country: GB
-            phone:
-              country_code: '+1'
-              number: 415 555 2671
-          3ds:
-            enabled: true
-            attempt_n3d: true
-            eci: '05'
-            cryptogram: AgAAAAAAAIR8CQrXcIhbQAAAAAA=
-            xid: MDAwMDAwMDAwMDAwMDAwMzIyNzY=
-            version: '2.0.1'
-          previous_payment_id: 'pay_fun26akvvjjerahhctaq2uzhu4'
-          risk:
-            enabled: false
-          success_url: 'http://example.com/payments/success'
-          failure_url: 'http://example.com/payments/fail'
-          payment_ip: '90.197.169.245'
-          recipient:
-            dob: '1985-05-15'
-            account_number: '5555554444'
-            zip: W1T
-            last_name: Jones
-          metadata:
-            coupon_code: 'NY2018'
-            partner_id: 123989
-
-  responses:
-    '201':
-      description: Payment processed successfully
+      To verify the success of the payment, check the `approved` field in the response.
+    parameters:
+      - $ref: '#/components/parameters/ckoIdempotencyKey'
+    requestBody:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/PaymentResponse'
+            oneOf:
+              - $ref: '#/components/schemas/PaymentRequest'
+              - $ref: '#/components/schemas/Payout'
           example:
-            id: 'pay_mbabizu24mvu3mela5njyhpit4'
-            action_id: 'act_mbabizu24mvu3mela5njyhpit4'
-            amount: 6540
-            currency: 'USD'
-            approved: true
-            status: 'Authorized'
-            auth_code: '770687'
-            response_code: '10000'
-            response_summary: 'Approved'
-            3ds:
-              downgraded: true
-              enrolled: 'N'
-            risk:
-              flagged: true
             source:
-              type: 'card'
-              id: 'src_nwd3m4in3hkuddfpjsaevunhdy'
-              billing_address:
-                address_line1: 'Checkout.com'
-                address_line2: '90 Tottenham Court Road'
-                city: 'London'
-                state: 'London'
-                zip: 'W1T 4TJ'
-                country: 'GB'
-              phone:
-                country_code: '+1'
-                number: '415 555 2671'
-              last4: '4242'
-              fingerprint: 'F31828E2BDABAE63EB694903825CDD36041CC6ED461440B81415895855502832'
-              bin: '424242'
+              type: token
+              token: tok_4gzeau5o2uqubbk6fufs3m7p54
+            amount: 6540
+            currency: USD
+            payment_type: Recurring
+            reference: 'ORD-5023-4E89'
+            description: 'Set of 3 masks'
+            capture: true
+            capture_on: '2019-09-10T10:11:12Z'
             customer:
               id: 'cus_udst2tfldj6upmye2reztkmm4i'
               email: 'brucewayne@gmail.com'
               name: 'Bruce Wayne'
-            processed_on: '2019-09-10T10:11:12Z'
-            reference: 'ORD-5023-4E89'
-            processing:
-              retrieval_reference_number: '909913440644'
-              acquirer_transaction_id: '440644309099499894406'
-            eci: '06'
-            scheme_id: '489341065491658'
-            _links:
-              self:
-                href: 'https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4'
-              action:
-                href: 'https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/actions'
-              void:
-                href: 'https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/voids'
-              capture:
-                href: 'https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/captures'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '202':
-      description: Payment asynchronous or further action required
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/PaymentAcceptedResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '429':
-      description: Too many requests or duplicate request detected
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '502':
-      description: Bad gateway
+            billing_descriptor:
+              name: SUPERHEROES.COM
+              city: GOTHAM
+            shipping:
+              address:
+                address_line1: Checkout.com
+                address_line2: 90 Tottenham Court Road
+                city: London
+                state: London
+                zip: W1T 4TJ
+                country: GB
+              phone:
+                country_code: '+1'
+                number: 415 555 2671
+            3ds:
+              enabled: true
+              attempt_n3d: true
+              eci: '05'
+              cryptogram: AgAAAAAAAIR8CQrXcIhbQAAAAAA=
+              xid: MDAwMDAwMDAwMDAwMDAwMzIyNzY=
+              version: '2.0.1'
+            previous_payment_id: 'pay_fun26akvvjjerahhctaq2uzhu4'
+            risk:
+              enabled: false
+            success_url: 'http://example.com/payments/success'
+            failure_url: 'http://example.com/payments/fail'
+            payment_ip: '90.197.169.245'
+            recipient:
+              dob: '1985-05-15'
+              account_number: '5555554444'
+              zip: W1T
+              last_name: Jones
+            metadata:
+              coupon_code: 'NY2018'
+              partner_id: 123989
+
+    responses:
+      '201':
+        description: Payment processed successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PaymentResponse'
+            example:
+              id: 'pay_mbabizu24mvu3mela5njyhpit4'
+              action_id: 'act_mbabizu24mvu3mela5njyhpit4'
+              amount: 6540
+              currency: 'USD'
+              approved: true
+              status: 'Authorized'
+              auth_code: '770687'
+              response_code: '10000'
+              response_summary: 'Approved'
+              3ds:
+                downgraded: true
+                enrolled: 'N'
+              risk:
+                flagged: true
+              source:
+                type: 'card'
+                id: 'src_nwd3m4in3hkuddfpjsaevunhdy'
+                billing_address:
+                  address_line1: 'Checkout.com'
+                  address_line2: '90 Tottenham Court Road'
+                  city: 'London'
+                  state: 'London'
+                  zip: 'W1T 4TJ'
+                  country: 'GB'
+                phone:
+                  country_code: '+1'
+                  number: '415 555 2671'
+                last4: '4242'
+                fingerprint: 'F31828E2BDABAE63EB694903825CDD36041CC6ED461440B81415895855502832'
+                bin: '424242'
+              customer:
+                id: 'cus_udst2tfldj6upmye2reztkmm4i'
+                email: 'brucewayne@gmail.com'
+                name: 'Bruce Wayne'
+              processed_on: '2019-09-10T10:11:12Z'
+              reference: 'ORD-5023-4E89'
+              processing:
+                retrieval_reference_number: '909913440644'
+                acquirer_transaction_id: '440644309099499894406'
+              eci: '06'
+              scheme_id: '489341065491658'
+              _links:
+                self:
+                  href: 'https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4'
+                action:
+                  href: 'https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/actions'
+                void:
+                  href: 'https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/voids'
+                capture:
+                  href: 'https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/captures'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '202':
+        description: Payment asynchronous or further action required
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PaymentAcceptedResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '429':
+        description: Too many requests or duplicate request detected
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '502':
+        description: Bad gateway

--- a/abc_spec/paths/payments@{id}.yaml
+++ b/abc_spec/paths/payments@{id}.yaml
@@ -1,39 +1,40 @@
-get:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Payments
-  summary: Get payment details
-  operationId: getPaymentDetails
-  description: |
-    Returns the details of the payment with the specified identifier string.
+/payments/{id}:
+  get:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Payments
+    summary: Get payment details
+    operationId: getPaymentDetails
+    description: |
+      Returns the details of the payment with the specified identifier string.
 
-    If the payment method requires a redirection to a third party (e.g., 3D Secure),
-    the redirect URL back to your site will include a `cko-session-id` query parameter
-    containing a payment session ID that can be used to obtain the details of the payment, for example:
+      If the payment method requires a redirection to a third party (e.g., 3D Secure),
+      the redirect URL back to your site will include a `cko-session-id` query parameter
+      containing a payment session ID that can be used to obtain the details of the payment, for example:
 
-    http://example.com/success?cko-session-id=sid_ubfj2q76miwundwlk72vxt2i7q.
-  parameters:
-    - in: path
-      name: id
-      schema:
-        type: string
-        pattern: "^(pay|sid)_(\\w{26})$"
-      required: true
-      description: The payment or payment session identifier
-  responses:
-    '200':
-      description: Payment retrieved successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Payment'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Payment not found
+      http://example.com/success?cko-session-id=sid_ubfj2q76miwundwlk72vxt2i7q.
+    parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          pattern: "^(pay|sid)_(\\w{26})$"
+        required: true
+        description: The payment or payment session identifier
+    responses:
+      '200':
+        description: Payment retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Payment'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Payment not found

--- a/abc_spec/paths/payments@{id}@actions.yaml
+++ b/abc_spec/paths/payments@{id}@actions.yaml
@@ -1,33 +1,34 @@
-get:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Payments
-  summary: Get payment actions
-  operationId: getPaymentActions
-  description: |
-    Returns all the actions associated with a payment ordered by processing date in descending order (latest first).
-  parameters:
-    - in: path
-      name: id
-      schema:
-        type: string
-        pattern: "^(pay)_(\\w{26})$"
-      required: true
-      description: The payment identifier
-  responses:
-    '200':
-      description: Payment actions retrieved successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/PaymentActionsResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Payment not found
+/payments/{id}/actions:
+  get:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Payments
+    summary: Get payment actions
+    operationId: getPaymentActions
+    description: |
+      Returns all the actions associated with a payment ordered by processing date in descending order (latest first).
+    parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          pattern: "^(pay)_(\\w{26})$"
+        required: true
+        description: The payment identifier
+    responses:
+      '200':
+        description: Payment actions retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PaymentActionsResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Payment not found

--- a/abc_spec/paths/payments@{id}@captures.yaml
+++ b/abc_spec/paths/payments@{id}@captures.yaml
@@ -1,51 +1,52 @@
-post:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Payments
-  summary: Capture a payment
-  operationId: captureAPayment
-  description: |
-    Captures a payment if supported by the payment method.
+/payments/{id}/captures:
+  post:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Payments
+    summary: Capture a payment
+    operationId: captureAPayment
+    description: |
+      Captures a payment if supported by the payment method.
 
-    For card payments, capture requests are processed asynchronously. You can use [webhooks](#tag/Webhooks) to be notified if the capture is successful.
-  parameters:
-    - $ref: '#/components/parameters/ckoIdempotencyKey'
-    - in: path
-      name: id
-      schema:
-        type: string
-        pattern: "^(pay)_(\\w{26})$"
-      required: true
-      description: The payment identifier
-  requestBody:
-    content:
-      application/json:
+      For card payments, capture requests are processed asynchronously. You can use [webhooks](#tag/Webhooks) to be notified if the capture is successful.
+    parameters:
+      - $ref: '#/components/parameters/ckoIdempotencyKey'
+      - in: path
+        name: id
         schema:
-          $ref: '#/components/schemas/CaptureRequest'
-  responses:
-    '202':
-      description: Capture accepted
+          type: string
+          pattern: "^(pay)_(\\w{26})$"
+        required: true
+        description: The payment identifier
+    requestBody:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/CaptureAcceptedResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '403':
-      description: Capture not allowed
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '404':
-      description: Payment not found
-    '502':
-      description: Bad gateway
+            $ref: '#/components/schemas/CaptureRequest'
+    responses:
+      '202':
+        description: Capture accepted
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CaptureAcceptedResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '403':
+        description: Capture not allowed
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '404':
+        description: Payment not found
+      '502':
+        description: Bad gateway

--- a/abc_spec/paths/payments@{id}@refunds.yaml
+++ b/abc_spec/paths/payments@{id}@refunds.yaml
@@ -1,51 +1,52 @@
-post:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Payments
-  summary: Refund a payment
-  operationId: refundAPayment
-  description: |
-    Refunds a payment if supported by the payment method.
+/payments/{id}/refunds:
+  post:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Payments
+    summary: Refund a payment
+    operationId: refundAPayment
+    description: |
+      Refunds a payment if supported by the payment method.
 
-    For card payments, refund requests are processed asynchronously. You can use [webhooks](#tag/Webhooks) to be notified if the refund is successful.
-  parameters:
-    - $ref: '#/components/parameters/ckoIdempotencyKey'
-    - in: path
-      name: id
-      schema:
-        type: string
-        pattern: "^(pay)_(\\w{26})$"
-      required: true
-      description: The payment identifier
-  requestBody:
-    content:
-      application/json:
+      For card payments, refund requests are processed asynchronously. You can use [webhooks](#tag/Webhooks) to be notified if the refund is successful.
+    parameters:
+      - $ref: '#/components/parameters/ckoIdempotencyKey'
+      - in: path
+        name: id
         schema:
-          $ref: '#/components/schemas/RefundRequest'
-  responses:
-    '202':
-      description: Refund accepted
+          type: string
+          pattern: "^(pay)_(\\w{26})$"
+        required: true
+        description: The payment identifier
+    requestBody:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/RefundAcceptedResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '403':
-      description: Refund not allowed
-    '404':
-      description: Payment not found
-    '502':
-      description: Bad gateway
+            $ref: '#/components/schemas/RefundRequest'
+    responses:
+      '202':
+        description: Refund accepted
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefundAcceptedResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '403':
+        description: Refund not allowed
+      '404':
+        description: Payment not found
+      '502':
+        description: Bad gateway

--- a/abc_spec/paths/payments@{id}@voids.yaml
+++ b/abc_spec/paths/payments@{id}@voids.yaml
@@ -1,51 +1,52 @@
-post:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Payments
-  summary: Void a payment
-  operationId: voidAPayment
-  description: |
-    Voids a payment if supported by the payment method.
+/payments/{id}/voids:
+  post:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Payments
+    summary: Void a payment
+    operationId: voidAPayment
+    description: |
+      Voids a payment if supported by the payment method.
 
-    For card payments, void requests are processed asynchronously. You can use [webhooks](#tag/Webhooks) to be notified if the void is successful.
-  parameters:
-    - $ref: '#/components/parameters/ckoIdempotencyKey'
-    - in: path
-      name: id
-      schema:
-        type: string
-        pattern: "^(pay)_(\\w{26})$"
-      required: true
-      description: The payment identifier
-  requestBody:
-    content:
-      application/json:
+      For card payments, void requests are processed asynchronously. You can use [webhooks](#tag/Webhooks) to be notified if the void is successful.
+    parameters:
+      - $ref: '#/components/parameters/ckoIdempotencyKey'
+      - in: path
+        name: id
         schema:
-          $ref: '#/components/schemas/VoidRequest'
-  responses:
-    '202':
-      description: Void accepted
+          type: string
+          pattern: "^(pay)_(\\w{26})$"
+        required: true
+        description: The payment identifier
+    requestBody:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/VoidAcceptedResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '403':
-      description: Void not allowed
-    '404':
-      description: Payment not found
-    '502':
-      description: Bad gateway
+            $ref: '#/components/schemas/VoidRequest'
+    responses:
+      '202':
+        description: Void accepted
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VoidAcceptedResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '403':
+        description: Void not allowed
+      '404':
+        description: Payment not found
+      '502':
+        description: Bad gateway

--- a/abc_spec/paths/reporting@payments.yaml
+++ b/abc_spec/paths/reporting@payments.yaml
@@ -1,65 +1,66 @@
-servers:
-  - url: https://api.checkout.com
-    description: Live API
+/reporting/payments:
+  servers:
+    - url: https://api.checkout.com
+      description: Live API
 
-get:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Reconciliation
-  summary: Get JSON payments report
-  operationId: getJsonPaymentsReport
-  description: Returns a JSON report containing all payments within your specified parameters.
-    You can reconcile the data from this report against your statements (which can be found in the <a href="https://hub.checkout.com/login" target="_blank">Hub</a>), the list of payments in the Hub (using the `Reference` field) or your own systems.
-    *Note:* no payments from before 7 February 2019 at 00.00.00 UTC will appear when using the payments endpoint. To view earlier payments, please contact our support team.
+  get:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Reconciliation
+    summary: Get JSON payments report
+    operationId: getJsonPaymentsReport
+    description: Returns a JSON report containing all payments within your specified parameters.
+      You can reconcile the data from this report against your statements (which can be found in the <a href="https://hub.checkout.com/login" target="_blank">Hub</a>), the list of payments in the Hub (using the `Reference` field) or your own systems.
+      *Note:* no payments from before 7 February 2019 at 00.00.00 UTC will appear when using the payments endpoint. To view earlier payments, please contact our support team.
 
-  parameters:
-    - in: query
-      name: from
-      schema:
-        type: string
-        format: date-time
-      required: false
-      description: Date and time from which to search for payments
-    - in: query
-      name: to
-      schema:
-        type: string
-        format: date-time
-      required: false
-      description: Date and time until which to search for payments
-    - in: query
-      name: reference
-      schema:
-        type: string
-      required: false
-      description: Reference of a specific payment to search for
-    - in: query
-      name: limit
-      schema:
-        type: integer
-        maximum: 500
-        default: 200
-      required: false
-      description: Sets a limit on the number of results
+    parameters:
+      - in: query
+        name: from
+        schema:
+          type: string
+          format: date-time
+        required: false
+        description: Date and time from which to search for payments
+      - in: query
+        name: to
+        schema:
+          type: string
+          format: date-time
+        required: false
+        description: Date and time until which to search for payments
+      - in: query
+        name: reference
+        schema:
+          type: string
+        required: false
+        description: Reference of a specific payment to search for
+      - in: query
+        name: limit
+        schema:
+          type: integer
+          maximum: 500
+          default: 200
+        required: false
+        description: Sets a limit on the number of results
 
-  responses:
-    '200':
-      description: Payments report retrieved successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/PaymentsReportResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '502':
-      description: Bad gateway
+    responses:
+      '200':
+        description: Payments report retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PaymentsReportResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '502':
+        description: Bad gateway

--- a/abc_spec/paths/reporting@payments@download.yaml
+++ b/abc_spec/paths/reporting@payments@download.yaml
@@ -1,32 +1,33 @@
-servers:
-  - url: https://api.checkout.com
-    description: Live API
+/reporting/payments/download:
+  servers:
+    - url: https://api.checkout.com
+      description: Live API
 
-get:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Reconciliation
-  summary: Get CSV payments report
-  responses:
-    '200':
-      description: CSV downloaded successfully
-  operationId: getCsvPaymentsReport
-  description:
-    In addition to the JSON format returned by the `reporting/payments` endpoint, you can also download a CSV report containing the same data.
-    Learn more about <a href="https://docs.checkout.com/reporting-and-insights/reconciliation-api/payments-endpoint#Paymentsendpoint-HowtoreadtheCSVfile" target="_blank">how to read your CSV report</a>.
-  parameters:
-    - in: query
-      name: from
-      schema:
-        type: string
-        format: date-time
-      required: false
-      description: Date and time from which to search for payments
-    - in: query
-      name: to
-      schema:
-        type: string
-        format: date-time
-      required: false
-      description: Date and time until which to search for payments
+  get:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Reconciliation
+    summary: Get CSV payments report
+    responses:
+      '200':
+        description: CSV downloaded successfully
+    operationId: getCsvPaymentsReport
+    description:
+      In addition to the JSON format returned by the `reporting/payments` endpoint, you can also download a CSV report containing the same data.
+      Learn more about <a href="https://docs.checkout.com/reporting-and-insights/reconciliation-api/payments-endpoint#Paymentsendpoint-HowtoreadtheCSVfile" target="_blank">how to read your CSV report</a>.
+    parameters:
+      - in: query
+        name: from
+        schema:
+          type: string
+          format: date-time
+        required: false
+        description: Date and time from which to search for payments
+      - in: query
+        name: to
+        schema:
+          type: string
+          format: date-time
+        required: false
+        description: Date and time until which to search for payments

--- a/abc_spec/paths/reporting@payments@{paymentId}.yaml
+++ b/abc_spec/paths/reporting@payments@{paymentId}.yaml
@@ -1,44 +1,45 @@
-servers:
-  - url: https://api.checkout.com
-    description: Live API
+/reporting/payments/{paymentId}:
+  servers:
+    - url: https://api.checkout.com
+      description: Live API
 
-get:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Reconciliation
-  summary: Get JSON single payment report
-  operationId: getJsonSinglePaymentReport
-  description:
-    Returns a JSON payment report containing all of the data related to a specific payment, based on the payment's identifier.
-    *Note:* no payments from before 7 February 2019 at 00.00.00 UTC will appear when using the payments endpoint. To view earlier payments, please contact our support team.
+  get:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Reconciliation
+    summary: Get JSON single payment report
+    operationId: getJsonSinglePaymentReport
+    description:
+      Returns a JSON payment report containing all of the data related to a specific payment, based on the payment's identifier.
+      *Note:* no payments from before 7 February 2019 at 00.00.00 UTC will appear when using the payments endpoint. To view earlier payments, please contact our support team.
 
-  parameters:
-    - in: path
-      name: paymentId
-      schema:
-        type: string
-        pattern: "^(pay)_(\\w{26})$"
-      required: true
-      description: The unique payment identifier
+    parameters:
+      - in: path
+        name: paymentId
+        schema:
+          type: string
+          pattern: "^(pay)_(\\w{26})$"
+        required: true
+        description: The unique payment identifier
 
-  responses:
-    '200':
-      description: Payment report returned successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/PaymentsReportResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '502':
-      description: Bad gateway
+    responses:
+      '200':
+        description: Payment report returned successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PaymentsReportResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '502':
+        description: Bad gateway

--- a/abc_spec/paths/reporting@statements.yaml
+++ b/abc_spec/paths/reporting@statements.yaml
@@ -1,49 +1,50 @@
-servers:
-  - url: https://api.checkout.com
-    description: Live API
+/reporting/statements:
+  servers:
+    - url: https://api.checkout.com
+      description: Live API
 
-get:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Reconciliation
-  summary: Get JSON statements report
-  operationId: getJsonStatementsReport
-  description: Returns a JSON report containing all statements within your specified parameters. Please note that the timezone for the request will be UTC.
+  get:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Reconciliation
+    summary: Get JSON statements report
+    operationId: getJsonStatementsReport
+    description: Returns a JSON report containing all statements within your specified parameters. Please note that the timezone for the request will be UTC.
 
-  parameters:
-    - in: query
-      name: from
-      schema:
-        type: string
-        format: date-time
-      required: false
-      description: Date and time from which to search for statements
-    - in: query
-      name: to
-      schema:
-        type: string
-        format: date-time
-      required: false
-      description: Date and time until which to search for statements
+    parameters:
+      - in: query
+        name: from
+        schema:
+          type: string
+          format: date-time
+        required: false
+        description: Date and time from which to search for statements
+      - in: query
+        name: to
+        schema:
+          type: string
+          format: date-time
+        required: false
+        description: Date and time until which to search for statements
 
-  responses:
-    '200':
-      description: Statements report successfully retrieved
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/StatementsReportResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '502':
-      description: Bad gateway
+    responses:
+      '200':
+        description: Statements report successfully retrieved
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StatementsReportResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '502':
+        description: Bad gateway

--- a/abc_spec/paths/reporting@statements@download.yaml
+++ b/abc_spec/paths/reporting@statements@download.yaml
@@ -1,15 +1,16 @@
-servers:
-  - url: https://api.checkout.com
-    description: Live API
+/reporting/statements/download:
+  servers:
+    - url: https://api.checkout.com
+      description: Live API
 
-get:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Reconciliation
-  responses:
-    '200':
-      description: CSV downloaded successfully
-  summary: Get CSV statements report
-  operationId: getCsvStatementsReport
-  description: In addition to the JSON format returned by the `reporting/statements` endpoint, you can also download a CSV report containing the same data.
+  get:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Reconciliation
+    responses:
+      '200':
+        description: CSV downloaded successfully
+    summary: Get CSV statements report
+    operationId: getCsvStatementsReport
+    description: In addition to the JSON format returned by the `reporting/statements` endpoint, you can also download a CSV report containing the same data.

--- a/abc_spec/paths/reporting@statements@{StatementId}@payments@download.yaml
+++ b/abc_spec/paths/reporting@statements@{StatementId}@payments@download.yaml
@@ -1,23 +1,24 @@
-servers:
-  - url: https://api.checkout.com
-    description: Live API
+/reporting/statements/{StatementId}/payments/download:
+  servers:
+    - url: https://api.checkout.com
+      description: Live API
 
-get:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Reconciliation
-  summary: Get CSV single statement report
-  operationId: GetCsvSingleStatementReport
-  description: Downloads a CSV statement report containing all of the data related to a specific statement, based on the statement's identifier.
-  responses:
-    '200':
-      description: CSV downloaded successfully
-  parameters:
-    - in: path
-      name: StatementId
-      example: '190110B107654'
-      schema:
-        type: string
-      required: true
-      description: The unique statement identifier
+  get:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Reconciliation
+    summary: Get CSV single statement report
+    operationId: GetCsvSingleStatementReport
+    description: Downloads a CSV statement report containing all of the data related to a specific statement, based on the statement's identifier.
+    responses:
+      '200':
+        description: CSV downloaded successfully
+    parameters:
+      - in: path
+        name: StatementId
+        example: '190110B107654'
+        schema:
+          type: string
+        required: true
+        description: The unique statement identifier

--- a/abc_spec/paths/risk@assessments@pre-authentication.yaml
+++ b/abc_spec/paths/risk@assessments@pre-authentication.yaml
@@ -1,49 +1,50 @@
-post:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Risk
-  summary: Request a pre-authentication risk scan
-  operationId: preAuthenticationRiskAssessment
-  description: |
-    Perform a pre-authentication fraud assessment using your defined risk settings.
-  #parameters:
-   # - $ref: '#/components/parameters/ckoIdempotencyKey'
-  requestBody:
-    content:
-      application/json:
-        schema:
-          $ref: '#/components/schemas/PreAuthenticationAssessmentRequest'
-  responses:
-  #   '200':
-  #     description: Transaction already assessed
-  #     content:
-  #       application/json:
-  #         schema:
-  #           $ref: '#/components/schemas/PreAuthenticationAssessmentResponse'
-  #       Cko-Request-Id:
-  #         $ref: "#/components/headers/Cko-Request-Id"
-  #       Cko-Version:
-  #         $ref: "#/components/headers/Cko-Version"
-    '201':
-      description: Transaction assessed successfully
+/risk/assessments/pre-authentication:
+  post:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Risk
+    summary: Request a pre-authentication risk scan
+    operationId: preAuthenticationRiskAssessment
+    description: |
+      Perform a pre-authentication fraud assessment using your defined risk settings.
+    #parameters:
+     # - $ref: '#/components/parameters/ckoIdempotencyKey'
+    requestBody:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/PreAuthenticationAssessmentResponse'
-        Cko-Request-Id:
-          schema:
-            $ref: "#/components/headers/Cko-Request-Id"
-        Cko-Version:
-          schema:
-            $ref: "#/components/headers/Cko-Version"
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '502':
-      description: Bad gateway
+            $ref: '#/components/schemas/PreAuthenticationAssessmentRequest'
+    responses:
+    #   '200':
+    #     description: Transaction already assessed
+    #     content:
+    #       application/json:
+    #         schema:
+    #           $ref: '#/components/schemas/PreAuthenticationAssessmentResponse'
+    #       Cko-Request-Id:
+    #         $ref: "#/components/headers/Cko-Request-Id"
+    #       Cko-Version:
+    #         $ref: "#/components/headers/Cko-Version"
+      '201':
+        description: Transaction assessed successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PreAuthenticationAssessmentResponse'
+          Cko-Request-Id:
+            schema:
+              $ref: "#/components/headers/Cko-Request-Id"
+          Cko-Version:
+            schema:
+              $ref: "#/components/headers/Cko-Version"
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '502':
+        description: Bad gateway

--- a/abc_spec/paths/risk@assessments@pre-capture.yaml
+++ b/abc_spec/paths/risk@assessments@pre-capture.yaml
@@ -1,51 +1,52 @@
-post:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Risk
-  summary: Request a pre-capture risk scan
-  operationId: preCaptureRiskAssessment
-  description: |
-    Perform a pre-capture fraud assessment using your defined risk settings.<br><br> **Note**: If you’ve already requested a pre-authentication fraud assessment for the transaction, provide the `assessment_id` returned in that response in your request to carry over the data. If you do include the `assessment_id`, the other fields you provide in this request will only fill in any gaps in the data; they will not overwrite any data.
-  # parameters:
-  #   - $ref: '#/components/parameters/ckoIdempotencyKey'
-  requestBody:
-    content:
-      application/json:
-        schema:
-          $ref: '#/components/schemas/PreCaptureAssessmentRequest'
-  responses:
-    '200':
-      description: Transaction already assessed
+/risk/assessments/pre-capture:
+  post:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Risk
+    summary: Request a pre-capture risk scan
+    operationId: preCaptureRiskAssessment
+    description: |
+      Perform a pre-capture fraud assessment using your defined risk settings.<br><br> **Note**: If you’ve already requested a pre-authentication fraud assessment for the transaction, provide the `assessment_id` returned in that response in your request to carry over the data. If you do include the `assessment_id`, the other fields you provide in this request will only fill in any gaps in the data; they will not overwrite any data.
+    # parameters:
+    #   - $ref: '#/components/parameters/ckoIdempotencyKey'
+    requestBody:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/PreCaptureAssessmentResponse'
-        Cko-Request-Id:
-          schema:
-            $ref: "#/components/headers/Cko-Request-Id"
-        Cko-Version:
-          schema:
-            $ref: "#/components/headers/Cko-Version"
-    '201':
-      description: Transaction assessed successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/PreCaptureAssessmentResponse'
-        Cko-Request-Id:
-          schema:
-            $ref: "#/components/headers/Cko-Request-Id"
-        Cko-Version:
-          schema:
-            $ref: "#/components/headers/Cko-Version"
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '502':
-      description: Bad gateway
+            $ref: '#/components/schemas/PreCaptureAssessmentRequest'
+    responses:
+      '200':
+        description: Transaction already assessed
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PreCaptureAssessmentResponse'
+          Cko-Request-Id:
+            schema:
+              $ref: "#/components/headers/Cko-Request-Id"
+          Cko-Version:
+            schema:
+              $ref: "#/components/headers/Cko-Version"
+      '201':
+        description: Transaction assessed successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PreCaptureAssessmentResponse'
+          Cko-Request-Id:
+            schema:
+              $ref: "#/components/headers/Cko-Request-Id"
+          Cko-Version:
+            schema:
+              $ref: "#/components/headers/Cko-Version"
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '502':
+        description: Bad gateway

--- a/abc_spec/paths/sources.yaml
+++ b/abc_spec/paths/sources.yaml
@@ -1,38 +1,39 @@
-post:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Sources
-  summary: Add a payment source
-  operationId: addAPaymentSource
-  description: |
-    Add a reusable payment source, like a <a href="https://docs.checkout.com/payment-methods/direct-debit/sepa-direct-debit" target="blank">SEPA Direct Debit</a>, that you can later use to make one or more payments.
-    Payment sources are linked to a specific customer and cannot be shared between customers.
+/sources:
+  post:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Sources
+    summary: Add a payment source
+    operationId: addAPaymentSource
+    description: |
+      Add a reusable payment source, like a <a href="https://docs.checkout.com/payment-methods/direct-debit/sepa-direct-debit" target="blank">SEPA Direct Debit</a>, that you can later use to make one or more payments.
+      Payment sources are linked to a specific customer and cannot be shared between customers.
 
-  requestBody:
-    content:
-      application/json:
-        schema:
-          $ref: '#/components/schemas/SourceRequest'
-  responses:
-    '201':
-      description: Payment source added successfully
+    requestBody:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AddSourceResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '502':
-      description: Bad gateway
+            $ref: '#/components/schemas/SourceRequest'
+    responses:
+      '201':
+        description: Payment source added successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddSourceResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '502':
+        description: Bad gateway

--- a/abc_spec/paths/tokens.yaml
+++ b/abc_spec/paths/tokens.yaml
@@ -1,38 +1,39 @@
-post:
-  security:
-    - ApiPublicKey: []
-  tags:
-    - Tokens
-  summary: Request a token
-  operationId: requestAToken
-  description: |
-    Exchange a digital wallet payment token or card details for a reference token that can be used later to request a card payment. Tokens are single use and expire after 15 minutes. 
-    To create a token, please authenticate using your public key. 
+/tokens:
+  post:
+    security:
+      - ApiPublicKey: []
+    tags:
+      - Tokens
+    summary: Request a token
+    operationId: requestAToken
+    description: |
+      Exchange a digital wallet payment token or card details for a reference token that can be used later to request a card payment. Tokens are single use and expire after 15 minutes.
+      To create a token, please authenticate using your public key.
 
-    **Please note:** You should only use the `card` type for testing purposes.
+      **Please note:** You should only use the `card` type for testing purposes.
 
-  requestBody:
-    content:
-      application/json:
-        schema:
-          $ref: '#/components/schemas/TokenRequest'
-  responses:
-    '201':
-      description: Reference token created successfully
+    requestBody:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/TokenResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
+            $ref: '#/components/schemas/TokenRequest'
+    responses:
+      '201':
+        description: Reference token created successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TokenResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'

--- a/abc_spec/paths/webhooks.yaml
+++ b/abc_spec/paths/webhooks.yaml
@@ -1,65 +1,66 @@
-get:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Webhooks
-  summary: Retrieve webhooks
-  operationId: retrieveWebhooks
-  description: |
-    Retrieves the webhooks configured for the channel identified by your API key
-  parameters: []
-  responses:
-    '200':
-      description: Configured webhooks
-      content:
-        application/json:
-          schema:
-            type: array
-            items:
-              $ref: '#/components/schemas/Webhook'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '204':
-      description: No webhooks configured
-    '401':
-      description: Unauthorized
+/webhooks:
+  get:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Webhooks
+    summary: Retrieve webhooks
+    operationId: retrieveWebhooks
+    description: |
+      Retrieves the webhooks configured for the channel identified by your API key
+    parameters: []
+    responses:
+      '200':
+        description: Configured webhooks
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: '#/components/schemas/Webhook'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '204':
+        description: No webhooks configured
+      '401':
+        description: Unauthorized
 
-post:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Webhooks
-  summary: Register webhook
-  operationId: registerWebhook
-  description: |
-    Register a new webhook endpoint that Checkout.com will post all or selected events to
-  requestBody:
-    content:
-      application/json:
-        schema:
-          $ref: '#/components/schemas/WebhookRequest'
-  responses:
-    '201':
-      description: Webhook registered successfully
+  post:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Webhooks
+    summary: Register webhook
+    operationId: registerWebhook
+    description: |
+      Register a new webhook endpoint that Checkout.com will post all or selected events to
+    requestBody:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Webhook'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '409':
-      description: URL already registered for another webhook
+            $ref: '#/components/schemas/WebhookRequest'
+    responses:
+      '201':
+        description: Webhook registered successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Webhook'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '409':
+        description: URL already registered for another webhook

--- a/abc_spec/paths/webhooks@{id}.yaml
+++ b/abc_spec/paths/webhooks@{id}.yaml
@@ -1,152 +1,153 @@
-get:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Webhooks
-  summary: Retrieve webhook
-  operationId: retrieveWebhook
-  description: |
-    Retrieves the webhook with the specified identifier string
-  parameters:
-    - name: id
-      required: true
-      schema:
-        type: string
-        pattern: "^(wh)_(\\w{32})$"
-      in: path
-      description: |
-        The webhook identifier
-      example: 'wh_387ac7a83a054e37ae140105429d76b5'
-  responses:
-    '200':
-      description: Webhook was retrieved successfully
-      content:
-        application/json:
-          schema:
-            type: object
-            allOf:
-              - $ref: '#/components/schemas/WebhookRequest'
-            required:
-              - url
-    '401':
-      description: Unauthorized
-    '404':
-      description: Webhook not found
-
-put:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Webhooks
-  summary: Update webhook
-  operationId: updateWebhook
-  description: |
-    Updates an existing webhook
-  parameters:
-    - name: id
-      required: true
-      schema:
-        type: string
-        pattern: "^(wh)_(\\w{32})$"
-      in: path
-      description: |
-        The webhook identifier
-      example: 'wh_387ac7a83a054e37ae140105429d76b5'
-  requestBody:
-    content:
-      application/json:
+/webhooks/{id}:
+  get:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Webhooks
+    summary: Retrieve webhook
+    operationId: retrieveWebhook
+    description: |
+      Retrieves the webhook with the specified identifier string
+    parameters:
+      - name: id
+        required: true
         schema:
-          $ref: '#/components/schemas/WebhookRequest'
-  responses:
-    '200':
-      description: Updated webhook
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Webhook'
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '404':
-      description: Webhook not found
-    '409':
-      description: URL already registered for another webhook
+          type: string
+          pattern: "^(wh)_(\\w{32})$"
+        in: path
+        description: |
+          The webhook identifier
+        example: 'wh_387ac7a83a054e37ae140105429d76b5'
+    responses:
+      '200':
+        description: Webhook was retrieved successfully
+        content:
+          application/json:
+            schema:
+              type: object
+              allOf:
+                - $ref: '#/components/schemas/WebhookRequest'
+              required:
+                - url
+      '401':
+        description: Unauthorized
+      '404':
+        description: Webhook not found
 
-patch:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Webhooks
-  summary: Partially update webhook
-  operationId: partiallyUpdateWebhook
-  description: Updates all or some of the registered webhook details
-  parameters:
-    - name: id
-      required: true
-      schema:
-        type: string
-        pattern: "^(wh)_(\\w{32})$"
-      in: path
-      description: |
-        The webhook identifier
-      example: 'wh_387ac7a83a054e37ae140105429d76b5'
-  requestBody:
-    content:
-      application/json:
+  put:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Webhooks
+    summary: Update webhook
+    operationId: updateWebhook
+    description: |
+      Updates an existing webhook
+    parameters:
+      - name: id
+        required: true
         schema:
-          $ref: '#/components/schemas/WebhookRequest'
-  responses:
-    '200':
-      description: Updated webhook
+          type: string
+          pattern: "^(wh)_(\\w{32})$"
+        in: path
+        description: |
+          The webhook identifier
+        example: 'wh_387ac7a83a054e37ae140105429d76b5'
+    requestBody:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Webhook'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '404':
-      description: Webhook not found
-    '409':
-      description: URL already exists in another webhook configuration
+            $ref: '#/components/schemas/WebhookRequest'
+    responses:
+      '200':
+        description: Updated webhook
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Webhook'
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '404':
+        description: Webhook not found
+      '409':
+        description: URL already registered for another webhook
 
-delete:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Webhooks
-  summary: Remove webhook
-  operationId: removeWebhook
-  description: Removes an existing webhook
-  parameters:
-    - name: id
-      required: true
-      schema:
-        type: string
-        pattern: "^(wh)_(\\w{32})$"
-      in: path
-      description: |
-        The webhook identifier
-      example: 'wh_387ac7a83a054e37ae140105429d76b5'
-  responses:
-    '200':
-      description: Webhook removed successfully
-    '401':
-      description: Unauthorized
-    '404':
-      description: Webhook not found
+  patch:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Webhooks
+    summary: Partially update webhook
+    operationId: partiallyUpdateWebhook
+    description: Updates all or some of the registered webhook details
+    parameters:
+      - name: id
+        required: true
+        schema:
+          type: string
+          pattern: "^(wh)_(\\w{32})$"
+        in: path
+        description: |
+          The webhook identifier
+        example: 'wh_387ac7a83a054e37ae140105429d76b5'
+    requestBody:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/WebhookRequest'
+    responses:
+      '200':
+        description: Updated webhook
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Webhook'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '404':
+        description: Webhook not found
+      '409':
+        description: URL already exists in another webhook configuration
+
+  delete:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Webhooks
+    summary: Remove webhook
+    operationId: removeWebhook
+    description: Removes an existing webhook
+    parameters:
+      - name: id
+        required: true
+        schema:
+          type: string
+          pattern: "^(wh)_(\\w{32})$"
+        in: path
+        description: |
+          The webhook identifier
+        example: 'wh_387ac7a83a054e37ae140105429d76b5'
+    responses:
+      '200':
+        description: Webhook removed successfully
+      '401':
+        description: Unauthorized
+      '404':
+        description: Webhook not found

--- a/nas_spec/paths/_marketplace-files.yaml
+++ b/nas_spec/paths/_marketplace-files.yaml
@@ -1,37 +1,38 @@
-post:
-  tags:
-    - Marketplace
-  security:
-    - OAuth:
-        - files
-  servers:
-    - url: https://files.checkout.com
-      description: Production server
-    - url: https://files.sandbox.checkout.com
-      description: Sandbox server
-  summary: Upload a file
-  description: >-
-    Our <a href="https://docs.checkout.com/four/d-marketplaces" target="_blank">Marketplace</a> solution provides an easy way to upload identity documentation required for full due diligence. Please <strong>note</strong> that the sub-domain – https://files.checkout.com – is slightly different to Checkout.com's other endpoints. <br><br>Read the <a href="https://docs.checkout.com/four/marketplaces/upload-a-file" target="_blank">documentation</a> for more information.
-  requestBody:
-    content:
-      multipart/form-data:
-        schema:
-          $ref: '#/components/schemas/MarketplaceFile'
-  responses:
-    '200':
-      description: File uploaded successfully
+/:
+  post:
+    tags:
+      - Marketplace
+    security:
+      - OAuth:
+          - files
+    servers:
+      - url: https://files.checkout.com
+        description: Production server
+      - url: https://files.sandbox.checkout.com
+        description: Sandbox server
+    summary: Upload a file
+    description: >-
+      Our <a href="https://docs.checkout.com/four/d-marketplaces" target="_blank">Marketplace</a> solution provides an easy way to upload identity documentation required for full due diligence. Please <strong>note</strong> that the sub-domain – https://files.checkout.com – is slightly different to Checkout.com's other endpoints. <br><br>Read the <a href="https://docs.checkout.com/four/marketplaces/upload-a-file" target="_blank">documentation</a> for more information.
+    requestBody:
       content:
-        application/json:
+        multipart/form-data:
           schema:
-            $ref: '#/components/schemas/MarketplaceFileUploadResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '422':
-      description: Unprocessable
-    '429':
-      description: Too many requests
+            $ref: '#/components/schemas/MarketplaceFile'
+    responses:
+      '200':
+        description: File uploaded successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MarketplaceFileUploadResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '422':
+        description: Unprocessable
+      '429':
+        description: Too many requests

--- a/nas_spec/paths/applepay@certificates.yaml
+++ b/nas_spec/paths/applepay@certificates.yaml
@@ -1,28 +1,29 @@
-post:
-  tags:
-    - Apple Pay
-  security: 
-    - ApiPublicKey: []
-  summary: Upload a payment processing certificate
-  description: |
-    Upload a payment processing certificate. This will allow you to start processing payments via Apple Pay.
-  requestBody:
-    content:
-      application/json:
-        schema:
-          $ref: '#/components/schemas/ApplePayCertificateRequest'
-  responses:
-    '201':
-      description: Certificate uploaded successfully
+/applepay/certificates:
+  post:
+    tags:
+      - Apple Pay
+    security:
+      - ApiPublicKey: []
+    summary: Upload a payment processing certificate
+    description: |
+      Upload a payment processing certificate. This will allow you to start processing payments via Apple Pay.
+    requestBody:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ApplePayCertificateResponse'
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
+            $ref: '#/components/schemas/ApplePayCertificateRequest'
+    responses:
+      '201':
+        description: Certificate uploaded successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApplePayCertificateResponse'
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'

--- a/nas_spec/paths/applepay@signing-requests.yaml
+++ b/nas_spec/paths/applepay@signing-requests.yaml
@@ -1,23 +1,24 @@
-post:
-  tags:
-    - Apple Pay
-  security: 
-    - ApiPublicKey: []
-  summary: Generate a certificate signing request
-  description: |
-    Generate a certificate signing request. You'll need to upload this to your Apple Developer account to download a payment processing certificate.
-  responses:
-    '200':
-      description: Generated signing request successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ApplePaySigningRequestResponse'
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
+/applepay/signing-requests:
+  post:
+    tags:
+      - Apple Pay
+    security:
+      - ApiPublicKey: []
+    summary: Generate a certificate signing request
+    description: |
+      Generate a certificate signing request. You'll need to upload this to your Apple Developer account to download a payment processing certificate.
+    responses:
+      '200':
+        description: Generated signing request successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ApplePaySigningRequestResponse'
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'

--- a/nas_spec/paths/connect@token.yaml
+++ b/nas_spec/paths/connect@token.yaml
@@ -1,71 +1,72 @@
-servers:
-  - url: https://access.checkout.com
-    description: Live API
-  - url: https://access.sandbox.checkout.com
-    description: Sandbox API
-post:
-  summary: Request an access token
-  tags:
-    - Access
-  responses:
-    '200':
-      description: OK - A successful access token response as per [RFC6749](https://tools.ietf.org/html/rfc6749#section-4.4.3)
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              access_token:
-                type: string
-                example: 2YotnFZFEjr1zCsicMWpAA
-              token_type:
-                type: string
-                example: example
-              expires_in:
-                type: number
-                example: 3600
+/connect/token:
+  servers:
+    - url: https://access.checkout.com
+      description: Live API
+    - url: https://access.sandbox.checkout.com
+      description: Sandbox API
+  post:
+    summary: Request an access token
+    tags:
+      - Access
+    responses:
+      '200':
+        description: OK - A successful access token response as per [RFC6749](https://tools.ietf.org/html/rfc6749#section-4.4.3)
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                access_token:
+                  type: string
+                  example: 2YotnFZFEjr1zCsicMWpAA
+                token_type:
+                  type: string
+                  example: example
+                expires_in:
+                  type: number
+                  example: 3600
 
-    '400':
-      description: Bad request - An unsuccessful access token response as per [RFC6749](https://tools.ietf.org/html/rfc6749#section-4.4.3)
+      '400':
+        description: Bad request - An unsuccessful access token response as per [RFC6749](https://tools.ietf.org/html/rfc6749#section-4.4.3)
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                error:
+                  type: string
+                  enum:
+                    - invalid_request
+                    - invalid_client
+                    - invalid_grant
+                    - unauthorized_client
+                    - unsupported_grant_type
+                    - invalid_scope
+    description: OAuth endpoint to exchange your access key ID and access key secret for an access token.
+    requestBody:
       content:
-        application/json:
+        application/x-www-form-urlencoded:
           schema:
             type: object
             properties:
-              error:
+              grant_type:
                 type: string
                 enum:
-                  - invalid_request
-                  - invalid_client
-                  - invalid_grant
-                  - unauthorized_client
-                  - unsupported_grant_type
-                  - invalid_scope
-  description: OAuth endpoint to exchange your access key ID and access key secret for an access token.
-  requestBody:
-    content:
-      application/x-www-form-urlencoded:
-        schema:
-          type: object
-          properties:
-            grant_type:
-              type: string
-              enum:
-                - client_credentials
-              example: client_credentials
-            client_id:
-              type: string
-              description: 'Access key ID'
-            client_secret:
-              type: string
-              description: 'Access key secret'
-            scope:
-              type: string
-              description: The access key scope
-              example: gateway
-        examples:
-          example-1:
-            value:
-              grant_type: client_credentials
-              client_id: ack_clckqmmnyfiupexjew7shh5ahe
-              client_secret: Pmg36sDWQ9WxtPR3
+                  - client_credentials
+                example: client_credentials
+              client_id:
+                type: string
+                description: 'Access key ID'
+              client_secret:
+                type: string
+                description: 'Access key secret'
+              scope:
+                type: string
+                description: The access key scope
+                example: gateway
+          examples:
+            example-1:
+              value:
+                grant_type: client_credentials
+                client_id: ack_clckqmmnyfiupexjew7shh5ahe
+                client_secret: Pmg36sDWQ9WxtPR3

--- a/nas_spec/paths/customers.yaml
+++ b/nas_spec/paths/customers.yaml
@@ -1,33 +1,34 @@
-post:
-  tags:
-    - Customers
-  security:
-    - OAuth:
-        - vault
-        - vault:customers
-    - ApiSecretKey: []
-  summary: Create a customer
-  description: Create a customer which can be linked to one or more payment instruments, and can be passed as a source when making a payment, using the customer’s default instrument.
-  requestBody:
-    required: true
-    content:
-      application/json:
-        schema:
-          $ref: '#/components/schemas/StoreCustomerRequest'
-  responses:
-    '201':
-      description: Customer created successfully
+/customers:
+  post:
+    tags:
+      - Customers
+    security:
+      - OAuth:
+          - vault
+          - vault:customers
+      - ApiSecretKey: []
+    summary: Create a customer
+    description: Create a customer which can be linked to one or more payment instruments, and can be passed as a source when making a payment, using the customer’s default instrument.
+    requestBody:
+      required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/StoreCustomerResponse'
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '500':
-      description: Internal Error
+            $ref: '#/components/schemas/StoreCustomerRequest'
+    responses:
+      '201':
+        description: Customer created successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StoreCustomerResponse'
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '500':
+        description: Internal Error

--- a/nas_spec/paths/customers@{identifier}.yaml
+++ b/nas_spec/paths/customers@{identifier}.yaml
@@ -1,109 +1,110 @@
-get:
-  security:
-    - OAuth:
-        - vault
-        - vault:customers
-    - ApiSecretKey: []
-  tags:
-    - Customers
-  summary: Get customer details
-  description: Returns the details of a customer and their payment instruments.
-  parameters:
-    - in: path
-      name: identifier
-      required: true
-      description: The customer's ID or email
-      schema:
-        type: string
-        properties:
-          id:
-            type: string
-            pattern: "^(cus)_(\\w{26})$"
-          email:
-            type: string
-            format: email
-            maxLength: 255
-        additionalProperties: false
-        oneOf:
-          - required: [id]
-          - required: [email]
-  responses:
-    '200':
-      description: Customer retrieved successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/RetrieveCustomerResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Customer not found
-
-patch:
-  tags:
-    - Customers
-  security:
-    - OAuth:
-        - vault
-        - vault:customers
-    - ApiSecretKey: []
-  summary: Update customer details
-  description: Update the details of a customer and link payment instruments to them.
-  parameters:
-    - in: path
-      name: identifier
-      schema:
-        type: string
-        pattern: "^(cus)_(\\w{26})$"
-      required: true
-      description: The customer's ID
-  requestBody:
-    required: true
-    content:
-      application/json:
+/customers/{identifier}:
+  get:
+    security:
+      - OAuth:
+          - vault
+          - vault:customers
+      - ApiSecretKey: []
+    tags:
+      - Customers
+    summary: Get customer details
+    description: Returns the details of a customer and their payment instruments.
+    parameters:
+      - in: path
+        name: identifier
+        required: true
+        description: The customer's ID or email
         schema:
-          $ref: '#/components/schemas/UpdateCustomerDetailsRequest'
-  responses:
-    '204':
-      description: Customer updated successfully
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
+          type: string
+          properties:
+            id:
+              type: string
+              pattern: "^(cus)_(\\w{26})$"
+            email:
+              type: string
+              format: email
+              maxLength: 255
+          additionalProperties: false
+          oneOf:
+            - required: [id]
+            - required: [email]
+    responses:
+      '200':
+        description: Customer retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RetrieveCustomerResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Customer not found
+
+  patch:
+    tags:
+      - Customers
+    security:
+      - OAuth:
+          - vault
+          - vault:customers
+      - ApiSecretKey: []
+    summary: Update customer details
+    description: Update the details of a customer and link payment instruments to them.
+    parameters:
+      - in: path
+        name: identifier
+        schema:
+          type: string
+          pattern: "^(cus)_(\\w{26})$"
+        required: true
+        description: The customer's ID
+    requestBody:
+      required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ValidationError'
-    '404':
-      description: Customer not found
+            $ref: '#/components/schemas/UpdateCustomerDetailsRequest'
+    responses:
+      '204':
+        description: Customer updated successfully
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '404':
+        description: Customer not found
 
-delete:
-  tags:
-    - Customers
-  security:
-    - OAuth:
-        - vault
-        - vault:customers
-    - ApiSecretKey: []
-  summary: Delete a customer
-  description: Delete a customer and all of their linked payment instruments.
-  parameters:
-    - in: path
-      name: identifier
-      required: true
-      schema:
-        type: string
-        pattern: "^(cus)_(\\w{26})$"
-      description: The customer's ID
-  responses:
-    '204':
-      description: Customer deleted successfully
-    '401':
-      description: Unauthorized
-    '404':
-      description: Customer not found or not associated with client
+  delete:
+    tags:
+      - Customers
+    security:
+      - OAuth:
+          - vault
+          - vault:customers
+      - ApiSecretKey: []
+    summary: Delete a customer
+    description: Delete a customer and all of their linked payment instruments.
+    parameters:
+      - in: path
+        name: identifier
+        required: true
+        schema:
+          type: string
+          pattern: "^(cus)_(\\w{26})$"
+        description: The customer's ID
+    responses:
+      '204':
+        description: Customer deleted successfully
+      '401':
+        description: Unauthorized
+      '404':
+        description: Customer not found or not associated with client

--- a/nas_spec/paths/disputes.yaml
+++ b/nas_spec/paths/disputes.yaml
@@ -1,126 +1,127 @@
-get:
-  tags:
-    - Disputes
-  security:
-    - OAuth:
-        - disputes
-        - disputes:view
-    - ApiSecretKey: []
-  summary: Get disputes
-  description: >-
-    Returns a list of all disputes against your business. The results will be
-    returned in reverse chronological order, showing the last modified dispute
-    (for example, where you've recently added a piece of evidence) first. You
-    can use the optional parameters below to skip or limit results.
-  parameters:
-    - in: query
-      name: limit
-      schema:
-        type: integer
-        minimum: 1
-        maximum: 250
-        default: 50
-      required: false
-      description: The numbers of results to return
-    - in: query
-      name: skip
-      schema:
-        type: integer
-        minimum: 0
-        default: 0
-      required: false
-      description: The number of results to skip
-    - in: query
-      name: from
-      schema:
-        type: string
-        format: ISO-8601
-      required: false
-      description: The date and time from which to filter disputes, based on the dispute's
-        `last_update` field
-    - in: query
-      name: to
-      schema:
-        type: string
-        format: ISO-8601
-      required: false
-      description: The date and time until which to filter disputes, based on the dispute's
-        `last_update` field
-    - in: query
-      name: id
-      schema:
-        type: string
-      required: false
-      description: The unique identifier of the dispute
-    - in: query
-      name: entity_ids
-      schema:
-        type: string
-        example: 'ent_wxglze3wwywujg4nna5fb7ldli,ent_vkb5zcy64zoe3cwfmaqvqyqyku'
-      required: false
-      description: One or more comma-separated client entities. This works like a logical *OR*
-        operator
-    - in: query
-      name: sub_entity_ids
-      schema:
-        type: string
-        example: 'ent_uzm3uxtssvmuxnyrfdffcyjxeu,ent_hy5wtzwzeuwefmsnjtdhw4scfi'
-      required: false
-      description: One or more comma-separated sub-entities. This works like a logical *OR*
-        operator
-    - in: query
-      name: statuses
-      schema:
-        type: string
-        example: 'evidence_required,evidence_under_review'
-      required: false
-      description: One or more comma-separated statuses. This works like a logical *OR*
-        operator
-    - in: query
-      name: payment_id
-      schema:
-        type: string
-      required: false
-      description: The unique identifier of the payment
-    - in: query
-      name: payment_reference
-      schema:
-        type: string
-      required: false
-      description: An optional reference (such as an order ID) that you can use later to identify the payment. Previously known as `TrackId`
-    - in: query
-      name: payment_arn
-      schema:
-        type: string
-      required: false
-      description: The acquirer reference number (ARN) that you can use to query the
-        issuing bank
-    - in: query
-      name: payment_mcc
-      schema:
-        type: string
-      required: false
-      description: The merchant category code (MCC) of the payment (ISO 18245)
-    - in: query
-      name: this_channel_only
-      schema:
-        type: boolean
-      required: false
-      description:
-        If `true`, only returns disputes of the specific channel that the secret key is associated with. Otherwise, returns all disputes for that
-        business
-  responses:
-    '200':
-      description: Disputes retrieved successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/DisputePaged'
-    '401':
-      description: Unauthorized
-    '422':
-      description: Unprocessable paging
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/PagingError'
+/disputes:
+  get:
+    tags:
+      - Disputes
+    security:
+      - OAuth:
+          - disputes
+          - disputes:view
+      - ApiSecretKey: []
+    summary: Get disputes
+    description: >-
+      Returns a list of all disputes against your business. The results will be
+      returned in reverse chronological order, showing the last modified dispute
+      (for example, where you've recently added a piece of evidence) first. You
+      can use the optional parameters below to skip or limit results.
+    parameters:
+      - in: query
+        name: limit
+        schema:
+          type: integer
+          minimum: 1
+          maximum: 250
+          default: 50
+        required: false
+        description: The numbers of results to return
+      - in: query
+        name: skip
+        schema:
+          type: integer
+          minimum: 0
+          default: 0
+        required: false
+        description: The number of results to skip
+      - in: query
+        name: from
+        schema:
+          type: string
+          format: ISO-8601
+        required: false
+        description: The date and time from which to filter disputes, based on the dispute's
+          `last_update` field
+      - in: query
+        name: to
+        schema:
+          type: string
+          format: ISO-8601
+        required: false
+        description: The date and time until which to filter disputes, based on the dispute's
+          `last_update` field
+      - in: query
+        name: id
+        schema:
+          type: string
+        required: false
+        description: The unique identifier of the dispute
+      - in: query
+        name: entity_ids
+        schema:
+          type: string
+          example: 'ent_wxglze3wwywujg4nna5fb7ldli,ent_vkb5zcy64zoe3cwfmaqvqyqyku'
+        required: false
+        description: One or more comma-separated client entities. This works like a logical *OR*
+          operator
+      - in: query
+        name: sub_entity_ids
+        schema:
+          type: string
+          example: 'ent_uzm3uxtssvmuxnyrfdffcyjxeu,ent_hy5wtzwzeuwefmsnjtdhw4scfi'
+        required: false
+        description: One or more comma-separated sub-entities. This works like a logical *OR*
+          operator
+      - in: query
+        name: statuses
+        schema:
+          type: string
+          example: 'evidence_required,evidence_under_review'
+        required: false
+        description: One or more comma-separated statuses. This works like a logical *OR*
+          operator
+      - in: query
+        name: payment_id
+        schema:
+          type: string
+        required: false
+        description: The unique identifier of the payment
+      - in: query
+        name: payment_reference
+        schema:
+          type: string
+        required: false
+        description: An optional reference (such as an order ID) that you can use later to identify the payment. Previously known as `TrackId`
+      - in: query
+        name: payment_arn
+        schema:
+          type: string
+        required: false
+        description: The acquirer reference number (ARN) that you can use to query the
+          issuing bank
+      - in: query
+        name: payment_mcc
+        schema:
+          type: string
+        required: false
+        description: The merchant category code (MCC) of the payment (ISO 18245)
+      - in: query
+        name: this_channel_only
+        schema:
+          type: boolean
+        required: false
+        description:
+          If `true`, only returns disputes of the specific channel that the secret key is associated with. Otherwise, returns all disputes for that
+          business
+    responses:
+      '200':
+        description: Disputes retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DisputePaged'
+      '401':
+        description: Unauthorized
+      '422':
+        description: Unprocessable paging
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PagingError'

--- a/nas_spec/paths/disputes@{dispute_id}.yaml
+++ b/nas_spec/paths/disputes@{dispute_id}.yaml
@@ -1,29 +1,30 @@
-get:
-  tags:
-    - Disputes
-  security:
-    - OAuth:
-        - disputes
-        - disputes:view
-    - ApiSecretKey: []
-  summary: Get dispute details
-  description: Returns all the details of a dispute using the dispute identifier.
-  parameters:
-    - in: path
-      name: dispute_id
-      schema:
-        type: string
-        pattern: '^(dsp)_(\\w{26})$'
-      required: true
-      description: The dispute identifier
-  responses:
-    '200':
-      description: Dispute retrieved successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/Dispute'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Dispute not found
+/disputes/{dispute_id}:
+  get:
+    tags:
+      - Disputes
+    security:
+      - OAuth:
+          - disputes
+          - disputes:view
+      - ApiSecretKey: []
+    summary: Get dispute details
+    description: Returns all the details of a dispute using the dispute identifier.
+    parameters:
+      - in: path
+        name: dispute_id
+        schema:
+          type: string
+          pattern: '^(dsp)_(\\w{26})$'
+        required: true
+        description: The dispute identifier
+    responses:
+      '200':
+        description: Dispute retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Dispute'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Dispute not found

--- a/nas_spec/paths/disputes@{dispute_id}@accept.yaml
+++ b/nas_spec/paths/disputes@{dispute_id}@accept.yaml
@@ -1,28 +1,29 @@
-post:
-  tags:
-    - Disputes
-  security:
-    - OAuth:
-        - disputes
-        - disputes:accept
-    - ApiSecretKey: []
-  summary: Accept dispute
-  description: >-
-    If a dispute is legitimate, you can choose to accept it. This will close it
-    for you and remove it from your list of open disputes. There are no further
-    financial implications.
-  parameters:
-    - in: path
-      name: dispute_id
-      schema:
-        type: string
-        pattern: '^(dsp)_(\w{26})$'
-      required: true
-      description: The dispute identifier
-  responses:
-    '204':
-      description: Dispute accepted successfully
-    '401':
-      description: Unauthorized
-    '404':
-      description: Dispute not found
+/disputes/{dispute_id}/accept:
+  post:
+    tags:
+      - Disputes
+    security:
+      - OAuth:
+          - disputes
+          - disputes:accept
+      - ApiSecretKey: []
+    summary: Accept dispute
+    description: >-
+      If a dispute is legitimate, you can choose to accept it. This will close it
+      for you and remove it from your list of open disputes. There are no further
+      financial implications.
+    parameters:
+      - in: path
+        name: dispute_id
+        schema:
+          type: string
+          pattern: '^(dsp)_(\w{26})$'
+        required: true
+        description: The dispute identifier
+    responses:
+      '204':
+        description: Dispute accepted successfully
+      '401':
+        description: Unauthorized
+      '404':
+        description: Dispute not found

--- a/nas_spec/paths/disputes@{dispute_id}@evidence.yaml
+++ b/nas_spec/paths/disputes@{dispute_id}@evidence.yaml
@@ -1,101 +1,102 @@
-put:
-  tags:
-    - Disputes
-  security:
-    - OAuth:
-        - disputes
-        - disputes:provide-evidence
-    - ApiSecretKey: []
-  summary: Provide dispute evidence
-  description: >
-    Adds supporting evidence to a dispute. Before using this endpoint, you first
-    need to [upload your files](#tag/Disputes/paths/~1files/post) using the file
-    uploader. You will receive a file id (prefixed by `file_`) which you can
-    then use in your request.
-    Note that this only attaches the evidence to the dispute, it does not send
-    it to us. Once ready, you will need to submit it.
-    **You must provide at least one evidence type in the body of your request.**
-  parameters:
-    - in: path
-      name: dispute_id
-      schema:
-        type: string
-        pattern: '^(dsp)_(\w{26})$'
-      required: true
-      description: The dispute identifier
-  requestBody:
-    content:
-      application/json:
+/disputes/{dispute_id}/evidence:
+  put:
+    tags:
+      - Disputes
+    security:
+      - OAuth:
+          - disputes
+          - disputes:provide-evidence
+      - ApiSecretKey: []
+    summary: Provide dispute evidence
+    description: >
+      Adds supporting evidence to a dispute. Before using this endpoint, you first
+      need to [upload your files](#tag/Disputes/paths/~1files/post) using the file
+      uploader. You will receive a file id (prefixed by `file_`) which you can
+      then use in your request.
+      Note that this only attaches the evidence to the dispute, it does not send
+      it to us. Once ready, you will need to submit it.
+      **You must provide at least one evidence type in the body of your request.**
+    parameters:
+      - in: path
+        name: dispute_id
         schema:
-          $ref: '#/components/schemas/ProvideEvidenceRequest'
-  responses:
-    '204':
-      description: Dispute evidence provided successfully
-    '400':
-      description: Unprocessable
-    '401':
-      description: Unauthorized
-    '404':
-      description: Dispute not found
-    '422':
-      description: Unprocessable entity
-get:
-  tags:
-    - Disputes
-  security:
-    - OAuth:
-        - disputes
-        - disputes:view
-    # - ApiKey: []
-  summary: Get dispute evidence
-  description: >
-    Retrieves a list of the evidence submitted in response to a specific
-    dispute.
-  parameters:
-    - in: path
-      name: dispute_id
-      schema:
-        type: string
-        pattern: '^(dsp)_(\w{26})$'
-      required: true
-      description: The dispute identifier
-  responses:
-    '200':
-      description: Dispute evidence retrieved successfully
+          type: string
+          pattern: '^(dsp)_(\w{26})$'
+        required: true
+        description: The dispute identifier
+    requestBody:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/Evidence'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Dispute not found
-post:
-  tags:
-    - Disputes
-  security:
-    - OAuth:
-        - disputes
-        - disputes:provide-evidence
-    # - ApiKey: []
-  summary: Submit dispute evidence
-  description: >-
-    With this final request, you can submit the evidence that you have
-    previously provided. Make sure you have provided all the relevant
-    information before using this request. You will not be able to amend your
-    evidence once you have submitted it.
-  parameters:
-    - in: path
-      name: dispute_id
-      schema:
-        type: string
-        pattern: '^(dsp)_(\w{26})$'
-      required: true
-      description: The dispute identifier
-  responses:
-    '204':
-      description: Dispute evidence submitted successfully
-    '401':
-      description: Unauthorized
-    '404':
-      description: Dispute not found
+            $ref: '#/components/schemas/ProvideEvidenceRequest'
+    responses:
+      '204':
+        description: Dispute evidence provided successfully
+      '400':
+        description: Unprocessable
+      '401':
+        description: Unauthorized
+      '404':
+        description: Dispute not found
+      '422':
+        description: Unprocessable entity
+  get:
+    tags:
+      - Disputes
+    security:
+      - OAuth:
+          - disputes
+          - disputes:view
+      # - ApiKey: []
+    summary: Get dispute evidence
+    description: >
+      Retrieves a list of the evidence submitted in response to a specific
+      dispute.
+    parameters:
+      - in: path
+        name: dispute_id
+        schema:
+          type: string
+          pattern: '^(dsp)_(\w{26})$'
+        required: true
+        description: The dispute identifier
+    responses:
+      '200':
+        description: Dispute evidence retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Evidence'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Dispute not found
+  post:
+    tags:
+      - Disputes
+    security:
+      - OAuth:
+          - disputes
+          - disputes:provide-evidence
+      # - ApiKey: []
+    summary: Submit dispute evidence
+    description: >-
+      With this final request, you can submit the evidence that you have
+      previously provided. Make sure you have provided all the relevant
+      information before using this request. You will not be able to amend your
+      evidence once you have submitted it.
+    parameters:
+      - in: path
+        name: dispute_id
+        schema:
+          type: string
+          pattern: '^(dsp)_(\w{26})$'
+        required: true
+        description: The dispute identifier
+    responses:
+      '204':
+        description: Dispute evidence submitted successfully
+      '401':
+        description: Unauthorized
+      '404':
+        description: Dispute not found

--- a/nas_spec/paths/files.yaml
+++ b/nas_spec/paths/files.yaml
@@ -1,35 +1,36 @@
-post:
-  tags:
-    - Disputes
-  security:
-    - OAuth:
-        - disputes
-        - disputes:provide-evidence
-    - ApiSecretKey: []
-  summary: Upload file
-  description: >-
-    Upload a file to use as evidence in a dispute. Your file must be in either
-    JPEG/JPG, PNG or PDF format, and be no larger than 4MB.
-  requestBody:
-    content:
-      multipart/form-data:
-        schema:
-          $ref: '#/components/schemas/File'
-  responses:
-    '200':
-      description: File uploaded successfully
+/files:
+  post:
+    tags:
+      - Disputes
+    security:
+      - OAuth:
+          - disputes
+          - disputes:provide-evidence
+      - ApiSecretKey: []
+    summary: Upload file
+    description: >-
+      Upload a file to use as evidence in a dispute. Your file must be in either
+      JPEG/JPG, PNG or PDF format, and be no larger than 4MB.
+    requestBody:
       content:
-        application/json:
+        multipart/form-data:
           schema:
-            $ref: '#/components/schemas/FileUploadResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '422':
-      description: Unprocessable
-    '429':
-      description: Too many requests
+            $ref: '#/components/schemas/File'
+    responses:
+      '200':
+        description: File uploaded successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FileUploadResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '422':
+        description: Unprocessable
+      '429':
+        description: Too many requests

--- a/nas_spec/paths/files@{file_id}.yaml
+++ b/nas_spec/paths/files@{file_id}.yaml
@@ -1,35 +1,36 @@
-get:
-  tags:
-    - Disputes
-  security:
-    - OAuth:
-        - disputes
-        - disputes:view
-    - ApiSecretKey: []
-  summary: Get file information
-  description: Retrieve information about a file that was previously uploaded.
-  parameters:
-    - in: path
-      name: file_id
-      schema:
-        type: string
-      required: true
-      description: The file identifier. It is always prefixed by `file_`.
-  responses:
-    '200':
-      description: File information retrieved successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/FileResult'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: File not found
-    '429':
-      description: Too many requests or duplicate request detected
+/files/{file_id}:
+  get:
+    tags:
+      - Disputes
+    security:
+      - OAuth:
+          - disputes
+          - disputes:view
+      - ApiSecretKey: []
+    summary: Get file information
+    description: Retrieve information about a file that was previously uploaded.
+    parameters:
+      - in: path
+        name: file_id
+        schema:
+          type: string
+        required: true
+        description: The file identifier. It is always prefixed by `file_`.
+    responses:
+      '200':
+        description: File information retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FileResult'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: File not found
+      '429':
+        description: Too many requests or duplicate request detected

--- a/nas_spec/paths/flow/workflows/workflows.yaml
+++ b/nas_spec/paths/flow/workflows/workflows.yaml
@@ -1,81 +1,82 @@
-get:
-  servers:
-    - url: https://api.checkout.com
-      description: Live API
-    - url: https://api.sandbox.checkout.com
-      description: Sandbox API
-  security:
-    - OAuth:
-        - flow
-        - flow:workflows
-    - ApiSecretKey: []
-  tags:
-    - Workflows
-  summary: Get all workflows
-  description: |
-    Get all workflows
-  responses:
-    '200':
-      description: Workflows retrieved successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/get-all-workflows-response'
-      headers:
-        Cko-Request-Id:
-          schema:
-            $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          schema:
-            $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '500':
-      description: Internal Error
+/workflows:
+  get:
+    servers:
+      - url: https://api.checkout.com
+        description: Live API
+      - url: https://api.sandbox.checkout.com
+        description: Sandbox API
+    security:
+      - OAuth:
+          - flow
+          - flow:workflows
+      - ApiSecretKey: []
+    tags:
+      - Workflows
+    summary: Get all workflows
+    description: |
+      Get all workflows
+    responses:
+      '200':
+        description: Workflows retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/get-all-workflows-response'
+        headers:
+          Cko-Request-Id:
+            schema:
+              $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            schema:
+              $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '500':
+        description: Internal Error
 
-post:
-  servers:
-    - url: https://api.checkout.com
-      description: Live API
-    - url: https://api.sandbox.checkout.com
-      description: Sandbox API
-  security:
-    - OAuth:
-        - flow
-        - flow:workflows
-    - ApiSecretKey: []
-  tags:
-    - Workflows
-  summary: Add a workflow
-  description: |
-    Add a new Flow workflow
-  requestBody:
-    required: true
-    content:
-      application/json:
-        schema:
-          $ref: '#/components/schemas/add-workflow-request'
-  responses:
-    '201':
-      description: Workflow added successfully
+  post:
+    servers:
+      - url: https://api.checkout.com
+        description: Live API
+      - url: https://api.sandbox.checkout.com
+        description: Sandbox API
+    security:
+      - OAuth:
+          - flow
+          - flow:workflows
+      - ApiSecretKey: []
+    tags:
+      - Workflows
+    summary: Add a workflow
+    description: |
+      Add a new Flow workflow
+    requestBody:
+      required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/add-workflow-response'
-      headers:
-        Cko-Request-Id:
-          schema:
-            $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          schema:
-            $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '500':
-      description: Internal Error
+            $ref: '#/components/schemas/add-workflow-request'
+    responses:
+      '201':
+        description: Workflow added successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/add-workflow-response'
+        headers:
+          Cko-Request-Id:
+            schema:
+              $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            schema:
+              $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '500':
+        description: Internal Error

--- a/nas_spec/paths/flow/workflows/workflows@event-types.yaml
+++ b/nas_spec/paths/flow/workflows/workflows@event-types.yaml
@@ -1,40 +1,41 @@
-get:
-  servers:
-    - url: https://api.checkout.com
-      description: Live API
-    - url: https://api.sandbox.checkout.com
-      description: Sandbox API
-  security:
-    - OAuth:
-        - flow
-        - flow:workflows
-    - ApiSecretKey: []
-  tags:
-    - Workflows
-  summary: Get event types
-  description: |
-    Get a list of sources and their events for building new workflows
-  responses:
-    '200':
-      description: Event types retrieved successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/get-event-types-response'
-      headers:
-        Cko-Request-Id:
-          schema:
-            $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          schema:
-            $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '500':
-      description: Internal Error
+/workflows/event-types:
+  get:
+    servers:
+      - url: https://api.checkout.com
+        description: Live API
+      - url: https://api.sandbox.checkout.com
+        description: Sandbox API
+    security:
+      - OAuth:
+          - flow
+          - flow:workflows
+      - ApiSecretKey: []
+    tags:
+      - Workflows
+    summary: Get event types
+    description: |
+      Get a list of sources and their events for building new workflows
+    responses:
+      '200':
+        description: Event types retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/get-event-types-response'
+        headers:
+          Cko-Request-Id:
+            schema:
+              $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            schema:
+              $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '500':
+        description: Internal Error

--- a/nas_spec/paths/flow/workflows/workflows@events@reflow.yaml
+++ b/nas_spec/paths/flow/workflows/workflows@events@reflow.yaml
@@ -1,41 +1,42 @@
-post:
-  security:
-    - OAuth:
-        - flow
-        - flow:reflow
-    - ApiSecretKey: []
-  tags:
-    - Workflows
-  summary: Reflow
-  description: |
-    Reflow past events attached to multiple event IDs and workflow IDs, or to multiple subject IDs and workflow IDs. If you don't specify any workflow IDs, all matching workflows will be retriggered.
-  requestBody:
-    required: true
-    content:
-      application/json:
-        schema:
-          oneOf:
-            - $ref: '#/components/schemas/reflow-events-by-event-and-workflow-ids'
-            - $ref: '#/components/schemas/reflow-events-by-subject-and-workflow-ids'
-  responses:
-    '202':
-      description: Event reflow initiated successfully
-      headers:
-        Cko-Request-Id:
-          schema:
-            $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          schema:
-            $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Events for reflow not found
-    '422':
-      description: Invalid data was sent
+/workflows/events/reflow:
+  post:
+    security:
+      - OAuth:
+          - flow
+          - flow:reflow
+      - ApiSecretKey: []
+    tags:
+      - Workflows
+    summary: Reflow
+    description: |
+      Reflow past events attached to multiple event IDs and workflow IDs, or to multiple subject IDs and workflow IDs. If you don't specify any workflow IDs, all matching workflows will be retriggered.
+    requestBody:
+      required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ids-validation-error'
-    '500':
-      description: Internal Error
+            oneOf:
+              - $ref: '#/components/schemas/reflow-events-by-event-and-workflow-ids'
+              - $ref: '#/components/schemas/reflow-events-by-subject-and-workflow-ids'
+    responses:
+      '202':
+        description: Event reflow initiated successfully
+        headers:
+          Cko-Request-Id:
+            schema:
+              $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            schema:
+              $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Events for reflow not found
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ids-validation-error'
+      '500':
+        description: Internal Error

--- a/nas_spec/paths/flow/workflows/workflows@events@subject@{subjectId}.yaml
+++ b/nas_spec/paths/flow/workflows/workflows@events@subject@{subjectId}.yaml
@@ -1,51 +1,52 @@
-get:
-  servers:
-    - url: https://api.checkout.com
-      description: Live API
-    - url: https://api.sandbox.checkout.com
-      description: Sandbox API
-  security:
-    - OAuth:
-        - flow
-        - flow:events
-    - ApiSecretKey: []
-  tags:
-    - Workflows
-  summary: Get subject events
-  description: |
-    Get all events that relate to a specific subject
-  parameters:
-    - in: path
-      name: subjectId
-      schema:
-        type: string
-      required: true
-      description: The event identifier
-      example: pay_wlu3wxc26jounofs5iez75qaqa
-  responses:
-    '200':
-      description: Events retrieved successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/subject-events-response'
-      headers:
-        Cko-Request-Id:
-          schema:
-            $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          schema:
-            $ref: '#/components/headers/Cko-Version'
-    '404':
-      description: Subject not found
-      headers:
-        Cko-Request-Id:
-          schema:
-            $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          schema:
-            $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '500':
-      description: Internal Error
+/workflows/events/subject/{subjectId}:
+  get:
+    servers:
+      - url: https://api.checkout.com
+        description: Live API
+      - url: https://api.sandbox.checkout.com
+        description: Sandbox API
+    security:
+      - OAuth:
+          - flow
+          - flow:events
+      - ApiSecretKey: []
+    tags:
+      - Workflows
+    summary: Get subject events
+    description: |
+      Get all events that relate to a specific subject
+    parameters:
+      - in: path
+        name: subjectId
+        schema:
+          type: string
+        required: true
+        description: The event identifier
+        example: pay_wlu3wxc26jounofs5iez75qaqa
+    responses:
+      '200':
+        description: Events retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/subject-events-response'
+        headers:
+          Cko-Request-Id:
+            schema:
+              $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            schema:
+              $ref: '#/components/headers/Cko-Version'
+      '404':
+        description: Subject not found
+        headers:
+          Cko-Request-Id:
+            schema:
+              $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            schema:
+              $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '500':
+        description: Internal Error

--- a/nas_spec/paths/flow/workflows/workflows@events@subject@{subjectId}@reflow.yaml
+++ b/nas_spec/paths/flow/workflows/workflows@events@subject@{subjectId}@reflow.yaml
@@ -1,42 +1,43 @@
-post:
-  security:
-    - OAuth:
-        - flow
-        - flow:reflow
-    - ApiSecretKey: []
-  tags:
-    - Workflows
-  summary: Reflow by subject
-  description: |
-    Reflows the events associated with a subject ID (for example, a payment ID or a dispute ID) and triggers the actions of any workflows with matching conditions.
-  parameters:
-    - in: path
-      name: subjectId
-      schema:
-        type: string
-        pattern: ^[a-z]{3}_[a-z0-9]{26}$
-      required: true
-      description: The subject identifier (for example, a payment ID or a dispute ID). The events associated with these subjects will be reflowed.
-      example: pay_x5zm2po6kimubhlfitgt2mfwgi
-  responses:
-    '202':
-      description: Event reflow initiated successfully
-      headers:
-        Cko-Request-Id:
-          schema:
-            $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          schema:
-            $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Events for reflow not found
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/subject-id-validation-error'
-    '500':
-      description: Internal Error
+/workflows/events/subject/{subjectId}/reflow:
+  post:
+    security:
+      - OAuth:
+          - flow
+          - flow:reflow
+      - ApiSecretKey: []
+    tags:
+      - Workflows
+    summary: Reflow by subject
+    description: |
+      Reflows the events associated with a subject ID (for example, a payment ID or a dispute ID) and triggers the actions of any workflows with matching conditions.
+    parameters:
+      - in: path
+        name: subjectId
+        schema:
+          type: string
+          pattern: ^[a-z]{3}_[a-z0-9]{26}$
+        required: true
+        description: The subject identifier (for example, a payment ID or a dispute ID). The events associated with these subjects will be reflowed.
+        example: pay_x5zm2po6kimubhlfitgt2mfwgi
+    responses:
+      '202':
+        description: Event reflow initiated successfully
+        headers:
+          Cko-Request-Id:
+            schema:
+              $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            schema:
+              $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Events for reflow not found
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/subject-id-validation-error'
+      '500':
+        description: Internal Error

--- a/nas_spec/paths/flow/workflows/workflows@events@subject@{subjectId}@workflow@{workflowId}@reflow.yaml
+++ b/nas_spec/paths/flow/workflows/workflows@events@subject@{subjectId}@workflow@{workflowId}@reflow.yaml
@@ -1,50 +1,51 @@
-post:
-  security:
-    - OAuth:
-        - flow
-        - flow:reflow
-    - ApiSecretKey: []
-  tags:
-    - Workflows
-  summary: Reflow by subject and workflow
-  description: |
-    Reflows the events associated with a subject ID (for example, a payment ID or a dispute ID) and triggers the actions of the specified workflow if the conditions match.
-  parameters:
-    - in: path
-      name: subjectId
-      schema:
-        type: string
-        pattern: ^[a-z]{3}_[a-z0-9]{26}$
-      required: true
-      description: The subject identifier (for example, a payment ID or a dispute ID). The events associated with these subjects will be reflowed.
-      example: pay_x5zm2po6kimubhlfitgt2mfwgi
-    - in: path
-      name: workflowId
-      schema:
-        type: string
-        pattern: ^wf_[a-z0-9]{26}$
-      required: true
-      description: The identifier of the workflow whose actions you want to trigger.
-      example: wf_c8zm2po6kimubhlfitgt2mferf
-  responses:
-    '202':
-      description: Event reflow initiated successfully
-      headers:
-        Cko-Request-Id:
-          schema:
-            $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          schema:
-            $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Events for reflow not found
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/subject-id-validation-error'
-    '500':
-      description: Internal Error
+/workflows/events/subject/{subjectId}/workflow/{workflowId}/reflow:
+  post:
+    security:
+      - OAuth:
+          - flow
+          - flow:reflow
+      - ApiSecretKey: []
+    tags:
+      - Workflows
+    summary: Reflow by subject and workflow
+    description: |
+      Reflows the events associated with a subject ID (for example, a payment ID or a dispute ID) and triggers the actions of the specified workflow if the conditions match.
+    parameters:
+      - in: path
+        name: subjectId
+        schema:
+          type: string
+          pattern: ^[a-z]{3}_[a-z0-9]{26}$
+        required: true
+        description: The subject identifier (for example, a payment ID or a dispute ID). The events associated with these subjects will be reflowed.
+        example: pay_x5zm2po6kimubhlfitgt2mfwgi
+      - in: path
+        name: workflowId
+        schema:
+          type: string
+          pattern: ^wf_[a-z0-9]{26}$
+        required: true
+        description: The identifier of the workflow whose actions you want to trigger.
+        example: wf_c8zm2po6kimubhlfitgt2mferf
+    responses:
+      '202':
+        description: Event reflow initiated successfully
+        headers:
+          Cko-Request-Id:
+            schema:
+              $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            schema:
+              $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Events for reflow not found
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/subject-id-validation-error'
+      '500':
+        description: Internal Error

--- a/nas_spec/paths/flow/workflows/workflows@events@{eventId}.yaml
+++ b/nas_spec/paths/flow/workflows/workflows@events@{eventId}.yaml
@@ -1,45 +1,46 @@
-get:
-  servers:
-    - url: https://api.checkout.com
-      description: Live API
-    - url: https://api.sandbox.checkout.com
-      description: Sandbox API
-  security:
-    - OAuth:
-        - flow
-        - flow:events
-    - ApiSecretKey: []
-  tags:
-    - Workflows
-  summary: Get an event
-  description: |
-    Get the details of an event
-  parameters:
-    - in: path
-      name: eventId
-      schema:
-        type: string
-        pattern: ^evt_[a-z0-9]{26}$
-      required: true
-      description: The event identifier
-      example: evt_x5zm2po6kimubhlfitgt2mfwgi
-  responses:
-    '200':
-      description: Event retrieved successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/get-event-response'
-      headers:
-        Cko-Request-Id:
-          schema:
-            $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          schema:
-            $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Event not found
-    '500':
-      description: Internal Error
+/workflows/events/{eventId}:
+  get:
+    servers:
+      - url: https://api.checkout.com
+        description: Live API
+      - url: https://api.sandbox.checkout.com
+        description: Sandbox API
+    security:
+      - OAuth:
+          - flow
+          - flow:events
+      - ApiSecretKey: []
+    tags:
+      - Workflows
+    summary: Get an event
+    description: |
+      Get the details of an event
+    parameters:
+      - in: path
+        name: eventId
+        schema:
+          type: string
+          pattern: ^evt_[a-z0-9]{26}$
+        required: true
+        description: The event identifier
+        example: evt_x5zm2po6kimubhlfitgt2mfwgi
+    responses:
+      '200':
+        description: Event retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/get-event-response'
+        headers:
+          Cko-Request-Id:
+            schema:
+              $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            schema:
+              $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Event not found
+      '500':
+        description: Internal Error

--- a/nas_spec/paths/flow/workflows/workflows@events@{eventId}@reflow.yaml
+++ b/nas_spec/paths/flow/workflows/workflows@events@{eventId}@reflow.yaml
@@ -1,42 +1,43 @@
-post:
-  security:
-    - OAuth:
-        - flow
-        - flow:reflow
-    - ApiSecretKey: []
-  tags:
-    - Workflows
-  summary: Reflow by event
-  description: |
-    Reflows a past event denoted by the event ID and triggers the actions of any workflows with matching conditions.
-  parameters:
-    - in: path
-      name: eventId
-      schema:
-        type: string
-        pattern: ^evt_[a-z0-9]{26}$
-      required: true
-      description: The unique identifier for the event to be reflowed.
-      example: evt_x5zm2po6kimubhlfitgt2mfwgi
-  responses:
-    '202':
-      description: Event reflow initiated successfully
-      headers:
-        Cko-Request-Id:
-          schema:
-            $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          schema:
-            $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Events for reflow not found
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/event-id-validation-error'
-    '500':
-      description: Internal Error
+/workflows/events/{eventId}/reflow:
+  post:
+    security:
+      - OAuth:
+          - flow
+          - flow:reflow
+      - ApiSecretKey: []
+    tags:
+      - Workflows
+    summary: Reflow by event
+    description: |
+      Reflows a past event denoted by the event ID and triggers the actions of any workflows with matching conditions.
+    parameters:
+      - in: path
+        name: eventId
+        schema:
+          type: string
+          pattern: ^evt_[a-z0-9]{26}$
+        required: true
+        description: The unique identifier for the event to be reflowed.
+        example: evt_x5zm2po6kimubhlfitgt2mfwgi
+    responses:
+      '202':
+        description: Event reflow initiated successfully
+        headers:
+          Cko-Request-Id:
+            schema:
+              $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            schema:
+              $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Events for reflow not found
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/event-id-validation-error'
+      '500':
+        description: Internal Error

--- a/nas_spec/paths/flow/workflows/workflows@events@{eventId}@workflow@{workflowId}@reflow.yaml
+++ b/nas_spec/paths/flow/workflows/workflows@events@{eventId}@workflow@{workflowId}@reflow.yaml
@@ -1,50 +1,51 @@
-post:
-  security:
-    - OAuth:
-        - flow
-        - flow:reflow
-    - ApiSecretKey: []
-  tags:
-    - Workflows
-  summary: Reflow by event and workflow
-  description: |
-    Reflows a past event by event ID and workflow ID. Triggers all the actions of a specific event and workflow combination if the event denoted by the event ID matches the workflow conditions.
-  parameters:
-    - in: path
-      name: eventId
-      schema:
-        type: string
-        pattern: ^evt_[a-z0-9]{26}$
-      required: true
-      description: The unique identifier for the event to be reflowed.
-      example: evt_x5zm2po6kimubhlfitgt2mfwgi
-    - in: path
-      name: workflowId
-      schema:
-        type: string
-        pattern: ^wf_[a-z0-9]{26}$
-      required: true
-      description: The identifier of the workflow whose actions you want to trigger.
-      example: wf_c8zm2po6kimubhlfitgt2mferf
-  responses:
-    '202':
-      description: Event reflow initiated successfully
-      headers:
-        Cko-Request-Id:
-          schema:
-            $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          schema:
-            $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Events for reflow not found
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/event-id-validation-error'
-    '500':
-      description: Internal Error
+/workflows/events/{eventId}/workflow/{workflowId}/reflow:
+  post:
+    security:
+      - OAuth:
+          - flow
+          - flow:reflow
+      - ApiSecretKey: []
+    tags:
+      - Workflows
+    summary: Reflow by event and workflow
+    description: |
+      Reflows a past event by event ID and workflow ID. Triggers all the actions of a specific event and workflow combination if the event denoted by the event ID matches the workflow conditions.
+    parameters:
+      - in: path
+        name: eventId
+        schema:
+          type: string
+          pattern: ^evt_[a-z0-9]{26}$
+        required: true
+        description: The unique identifier for the event to be reflowed.
+        example: evt_x5zm2po6kimubhlfitgt2mfwgi
+      - in: path
+        name: workflowId
+        schema:
+          type: string
+          pattern: ^wf_[a-z0-9]{26}$
+        required: true
+        description: The identifier of the workflow whose actions you want to trigger.
+        example: wf_c8zm2po6kimubhlfitgt2mferf
+    responses:
+      '202':
+        description: Event reflow initiated successfully
+        headers:
+          Cko-Request-Id:
+            schema:
+              $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            schema:
+              $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Events for reflow not found
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/event-id-validation-error'
+      '500':
+        description: Internal Error

--- a/nas_spec/paths/flow/workflows/workflows@{workflowId}.yaml
+++ b/nas_spec/paths/flow/workflows/workflows@{workflowId}.yaml
@@ -1,140 +1,141 @@
-﻿get:
-  servers:
-    - url: https://api.checkout.com
-      description: Live API
-    - url: https://api.sandbox.checkout.com
-      description: Sandbox API
-  security:
-    - OAuth:
-        - flow
-        - flow:workflows
-    - ApiSecretKey: []
-  tags:
-    - Workflows
-  summary: Get a workflow
-  description: |
-    Get the details of a workflow
-  parameters:
-    - in: path
-      name: workflowId
-      schema:
-        type: string
-        pattern: ^wf_[a-z0-9]{26}$
-      required: true
-      description: The workflow identifier
-      example: wf_c7svxlvo2bbuva4f6s3xu4f7wm
-  responses:
-    '200':
-      description: Workflow retrieved successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/get-workflow-response'
-      headers:
-        Cko-Request-Id:
-          schema:
-            $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          schema:
-            $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Workflow not found
-    '500':
-      description: Internal Error
-
-delete:
-  servers:
-    - url: https://api.checkout.com
-      description: Live API
-    - url: https://api.sandbox.checkout.com
-      description: Sandbox API
-  security:
-    - OAuth:
-        - flow
-        - flow:workflows
-    - ApiSecretKey: []
-  tags:
-    - Workflows
-  summary: Remove a workflow
-  description: |
-    Removes a workflow so it is no longer being executed. 
-    Actions of already executed workflows will be still processed.
-  parameters:
-    - in: path
-      name: workflowId
-      schema:
-        type: string
-        pattern: ^wf_[a-z0-9]{26}$
-      required: true
-      description: The workflow identifier
-      example: wf_c7svxlvo2bbuva4f6s3xu4f7wm
-  responses:
-    '204':
-      description: Workflow removed successfully
-      headers:
-        Cko-Request-Id:
-          schema:
-            $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          schema:
-            $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Workflow not found
-    '500':
-      description: Internal Error
-
-patch:
-  servers:
-    - url: https://api.checkout.com
-      description: Live API
-    - url: https://api.sandbox.checkout.com
-      description: Sandbox API
-  security:
-    - OAuth:
-        - flow
-        - flow:workflows
-    - ApiSecretKey: []
-  tags:
-    - Workflows
-  summary: Patch a workflow
-  description: |
-    Update the name of a workflow.
-  parameters:
-    - in: path
-      name: workflowId
-      schema:
-        type: string
-        pattern: ^wf_[a-z0-9]{26}$
-      required: true
-      description: The workflow identifier
-      example: wf_c7svxlvo2bbuva4f6s3xu4f7wm
-  requestBody:
-    required: true
-    content:
-      application/json:
+﻿/workflows/{workflowId}:
+  get:
+    servers:
+      - url: https://api.checkout.com
+        description: Live API
+      - url: https://api.sandbox.checkout.com
+        description: Sandbox API
+    security:
+      - OAuth:
+          - flow
+          - flow:workflows
+      - ApiSecretKey: []
+    tags:
+      - Workflows
+    summary: Get a workflow
+    description: |
+      Get the details of a workflow
+    parameters:
+      - in: path
+        name: workflowId
         schema:
-          $ref: '#/components/schemas/patch-workflow-request'
-  responses:
-    '200':
-      description: Workflow updated successfully
+          type: string
+          pattern: ^wf_[a-z0-9]{26}$
+        required: true
+        description: The workflow identifier
+        example: wf_c7svxlvo2bbuva4f6s3xu4f7wm
+    responses:
+      '200':
+        description: Workflow retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/get-workflow-response'
+        headers:
+          Cko-Request-Id:
+            schema:
+              $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            schema:
+              $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Workflow not found
+      '500':
+        description: Internal Error
+
+  delete:
+    servers:
+      - url: https://api.checkout.com
+        description: Live API
+      - url: https://api.sandbox.checkout.com
+        description: Sandbox API
+    security:
+      - OAuth:
+          - flow
+          - flow:workflows
+      - ApiSecretKey: []
+    tags:
+      - Workflows
+    summary: Remove a workflow
+    description: |
+      Removes a workflow so it is no longer being executed.
+      Actions of already executed workflows will be still processed.
+    parameters:
+      - in: path
+        name: workflowId
+        schema:
+          type: string
+          pattern: ^wf_[a-z0-9]{26}$
+        required: true
+        description: The workflow identifier
+        example: wf_c7svxlvo2bbuva4f6s3xu4f7wm
+    responses:
+      '204':
+        description: Workflow removed successfully
+        headers:
+          Cko-Request-Id:
+            schema:
+              $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            schema:
+              $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Workflow not found
+      '500':
+        description: Internal Error
+
+  patch:
+    servers:
+      - url: https://api.checkout.com
+        description: Live API
+      - url: https://api.sandbox.checkout.com
+        description: Sandbox API
+    security:
+      - OAuth:
+          - flow
+          - flow:workflows
+      - ApiSecretKey: []
+    tags:
+      - Workflows
+    summary: Patch a workflow
+    description: |
+      Update the name of a workflow.
+    parameters:
+      - in: path
+        name: workflowId
+        schema:
+          type: string
+          pattern: ^wf_[a-z0-9]{26}$
+        required: true
+        description: The workflow identifier
+        example: wf_c7svxlvo2bbuva4f6s3xu4f7wm
+    requestBody:
+      required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/patch-workflow-response'
-      headers:
-        Cko-Request-Id:
-          schema:
-            $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          schema:
-            $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Workflow not found
-    '500':
-      description: Internal Error
+            $ref: '#/components/schemas/patch-workflow-request'
+    responses:
+      '200':
+        description: Workflow updated successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/patch-workflow-response'
+        headers:
+          Cko-Request-Id:
+            schema:
+              $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            schema:
+              $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Workflow not found
+      '500':
+        description: Internal Error

--- a/nas_spec/paths/flow/workflows/workflows@{workflowId}@actions@{workflowActionId}.yaml
+++ b/nas_spec/paths/flow/workflows/workflows@{workflowId}@actions@{workflowActionId}.yaml
@@ -1,61 +1,62 @@
-﻿put:
-  servers:
-    - url: https://api.checkout.com
-      description: Live API
-    - url: https://api.sandbox.checkout.com
-      description: Sandbox API
-  security:
-    - OAuth:
-        - flow
-        - flow:workflows
-    - ApiSecretKey: []
-  tags:
-    - Workflows
-  summary: Update a workflow action
-  description: |
-    Update a workflow action.
-  parameters:
-    - in: path
-      name: workflowId
-      schema:
-        type: string
-        pattern: ^wf_[a-z0-9]{26}$
-      required: true
-      description: The workflow identifier
-      example: wf_c7svxlvo2bbuva4f6s3xu4f7wm
-    - in: path
-      name: workflowActionId
-      schema:
-        type: string
-        pattern: ^wfa_[a-z0-9]{26}$
-      required: true
-      description: The workflow action identifier
-      example: wfa_d5estuyxzshubhly2wu3hloehi
-  requestBody:
-    required: true
-    content:
-      application/json:
+﻿/workflows/{workflowId}/actions/{workflowActionId}:
+  put:
+    servers:
+      - url: https://api.checkout.com
+        description: Live API
+      - url: https://api.sandbox.checkout.com
+        description: Sandbox API
+    security:
+      - OAuth:
+          - flow
+          - flow:workflows
+      - ApiSecretKey: []
+    tags:
+      - Workflows
+    summary: Update a workflow action
+    description: |
+      Update a workflow action.
+    parameters:
+      - in: path
+        name: workflowId
         schema:
-          $ref: '#/components/schemas/add-update-workflow-action-request'
-  responses:
-    '200':
-      description: Workflow action updated successfully
-      headers:
-        Cko-Request-Id:
-          schema:
-            $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          schema:
-            $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Workflow or workflow action not found
-    '422':
-      description: Invalid data was sent
+          type: string
+          pattern: ^wf_[a-z0-9]{26}$
+        required: true
+        description: The workflow identifier
+        example: wf_c7svxlvo2bbuva4f6s3xu4f7wm
+      - in: path
+        name: workflowActionId
+        schema:
+          type: string
+          pattern: ^wfa_[a-z0-9]{26}$
+        required: true
+        description: The workflow action identifier
+        example: wfa_d5estuyxzshubhly2wu3hloehi
+    requestBody:
+      required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ValidationError'
-    '500':
-      description: Internal Error
+            $ref: '#/components/schemas/add-update-workflow-action-request'
+    responses:
+      '200':
+        description: Workflow action updated successfully
+        headers:
+          Cko-Request-Id:
+            schema:
+              $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            schema:
+              $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Workflow or workflow action not found
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '500':
+        description: Internal Error

--- a/nas_spec/paths/flow/workflows/workflows@{workflowId}@conditions@{workflowConditionId}.yaml
+++ b/nas_spec/paths/flow/workflows/workflows@{workflowId}@conditions@{workflowConditionId}.yaml
@@ -1,61 +1,62 @@
-﻿put:
-  servers:
-    - url: https://api.checkout.com
-      description: Live API
-    - url: https://api.sandbox.checkout.com
-      description: Sandbox API
-  security:
-    - OAuth:
-        - flow
-        - flow:workflows
-    - ApiSecretKey: []
-  tags:
-    - Workflows
-  summary: Update a workflow condition
-  description: |
-    Update a workflow condition.
-  parameters:
-    - in: path
-      name: workflowId
-      schema:
-        type: string
-        pattern: ^wf_[a-z0-9]{26}$
-      required: true
-      description: The workflow identifier
-      example: wf_c7svxlvo2bbuva4f6s3xu4f7wm
-    - in: path
-      name: workflowConditionId
-      schema:
-        type: string
-        pattern: ^wfc_[a-z0-9]{26}$
-      required: true
-      description: The workflow condition identifier
-      example: wfc_d5estuyxzshubhly2wu3hloehi
-  requestBody:
-    required: true
-    content:
-      application/json:
+﻿/workflows/{workflowId}/conditions/{workflowConditionId}:
+  put:
+    servers:
+      - url: https://api.checkout.com
+        description: Live API
+      - url: https://api.sandbox.checkout.com
+        description: Sandbox API
+    security:
+      - OAuth:
+          - flow
+          - flow:workflows
+      - ApiSecretKey: []
+    tags:
+      - Workflows
+    summary: Update a workflow condition
+    description: |
+      Update a workflow condition.
+    parameters:
+      - in: path
+        name: workflowId
         schema:
-          $ref: '#/components/schemas/add-update-workflow-condition-request'
-  responses:
-    '200':
-      description: Workflow condition updated successfully
-      headers:
-        Cko-Request-Id:
-          schema:
-            $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          schema:
-            $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Workflow or workflow condition not found
-    '422':
-      description: Invalid data was sent
+          type: string
+          pattern: ^wf_[a-z0-9]{26}$
+        required: true
+        description: The workflow identifier
+        example: wf_c7svxlvo2bbuva4f6s3xu4f7wm
+      - in: path
+        name: workflowConditionId
+        schema:
+          type: string
+          pattern: ^wfc_[a-z0-9]{26}$
+        required: true
+        description: The workflow condition identifier
+        example: wfc_d5estuyxzshubhly2wu3hloehi
+    requestBody:
+      required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/ValidationError'
-    '500':
-      description: Internal Error
+            $ref: '#/components/schemas/add-update-workflow-condition-request'
+    responses:
+      '200':
+        description: Workflow condition updated successfully
+        headers:
+          Cko-Request-Id:
+            schema:
+              $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            schema:
+              $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Workflow or workflow condition not found
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '500':
+        description: Internal Error

--- a/nas_spec/paths/forex@quotes.yaml
+++ b/nas_spec/paths/forex@quotes.yaml
@@ -1,42 +1,43 @@
-post:
-  tags:
-    - Forex
-  security:
-    - OAuth:
-        - fx
-  summary: Request a quote
-  description: |
-    Request an exchange rate between a source and destination currency pair that will be used to process one or more payouts. You must submit a payout with the FX quote identifier before the quote expires. If the FX quote identifier is omitted from a payout, and the source and destination currencies differ, the current market exchange rate will be used.
-  requestBody:
-    content:
-      application/json:
-        schema:
-          $ref: '#/components/schemas/QuoteRequest'
-  responses:
-    '201':
-      description: Quote created
+/forex/quotes:
+  post:
+    tags:
+      - Forex
+    security:
+      - OAuth:
+          - fx
+    summary: Request a quote
+    description: |
+      Request an exchange rate between a source and destination currency pair that will be used to process one or more payouts. You must submit a payout with the FX quote identifier before the quote expires. If the FX quote identifier is omitted from a payout, and the source and destination currencies differ, the current market exchange rate will be used.
+    requestBody:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/QuoteResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '429':
-      description: Too many requests or duplicate request detected
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '502':
-      description: Bad gateway
+            $ref: '#/components/schemas/QuoteRequest'
+    responses:
+      '201':
+        description: Quote created
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/QuoteResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '429':
+        description: Too many requests or duplicate request detected
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '502':
+        description: Bad gateway

--- a/nas_spec/paths/instruments.yaml
+++ b/nas_spec/paths/instruments.yaml
@@ -1,34 +1,35 @@
-post:
-  tags:
-    - Instruments
-  security:
-    - OAuth:
-        - vault
-        - vault:instruments
-    - ApiSecretKey: []
-  summary: Create an instrument
-  description: |
-    Create a card or bank account payment instrument to use for future payments and payouts. <br><br>The parameters you need to provide when creating a bank account payment instrument depend on the account's country and currency. See <a href="https://docs.checkout.com/four/bank-payouts/payout-formatting" target="_blank">our docs</a> and the <a href="#tag/Instruments/paths/~1validation~1bank-accounts~1{country}~1{currency}/get">GET endpoint below</a>.
-  requestBody:
-    required: true
-    content:
-      application/json:
-        schema:
-          $ref: '#/components/schemas/StoreInstrumentRequest'
-  responses:
-    '201':
-      description: Instrument created successfully
+/instruments:
+  post:
+    tags:
+      - Instruments
+    security:
+      - OAuth:
+          - vault
+          - vault:instruments
+      - ApiSecretKey: []
+    summary: Create an instrument
+    description: |
+      Create a card or bank account payment instrument to use for future payments and payouts. <br><br>The parameters you need to provide when creating a bank account payment instrument depend on the account's country and currency. See <a href="https://docs.checkout.com/four/bank-payouts/payout-formatting" target="_blank">our docs</a> and the <a href="#tag/Instruments/paths/~1validation~1bank-accounts~1{country}~1{currency}/get">GET endpoint below</a>.
+    requestBody:
+      required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/StoreInstrumentResponse'
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '500':
-      description: Internal Error
+            $ref: '#/components/schemas/StoreInstrumentRequest'
+    responses:
+      '201':
+        description: Instrument created successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StoreInstrumentResponse'
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '500':
+        description: Internal Error

--- a/nas_spec/paths/instruments@{id}.yaml
+++ b/nas_spec/paths/instruments@{id}.yaml
@@ -1,116 +1,117 @@
-get:
-  security:
-    - OAuth:
-        - vault
-        - vault:instruments
-    - ApiSecretKey: []
-  tags:
-    - Instruments
-  summary: Get instrument details
-  operationId: getInstrumentDetails
-  description: Retrieve the details of a payment instrument.
-  parameters:
-    - in: path
-      name: id
-      schema:
-        type: string
-        pattern: "^(src)_(\\w{26})$"
-      required: true
-      description: The instrument ID
-  responses:
-    '200':
-      description: Instrument retrieved successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/RetrieveInstrumentResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Instrument not found
-
-patch:
-  tags:
-    - Instruments
-  security:
-    - OAuth:
-        - vault
-        - vault:instruments
-    - ApiSecretKey: []
-  summary: Update an instrument
-  description: |
-    Update the details of a payment instrument.
-  parameters:
-    - in: path
-      name: id
-      required: true
-      schema:
-        type: string
-        pattern: '^(src_)[a-z0-9]{26}$'
-      example: src_ubfj2q76miwundwlk72vxt2i7q
-      description: The instrument ID
-  requestBody:
-    required: true
-    content:
-      application/json:
+/instruments/{id}:
+  get:
+    security:
+      - OAuth:
+          - vault
+          - vault:instruments
+      - ApiSecretKey: []
+    tags:
+      - Instruments
+    summary: Get instrument details
+    operationId: getInstrumentDetails
+    description: Retrieve the details of a payment instrument.
+    parameters:
+      - in: path
+        name: id
         schema:
-          $ref: '#/components/schemas/UpdateInstrumentRequest'
-  responses:
-    '200':
-      description: Instrument updated successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/UpdateInstrumentResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Instrument not found or not associated with client
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '500':
-      description: Internal Error
+          type: string
+          pattern: "^(src)_(\\w{26})$"
+        required: true
+        description: The instrument ID
+    responses:
+      '200':
+        description: Instrument retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RetrieveInstrumentResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Instrument not found
 
-delete:
-  tags:
-    - Instruments
-  security:
-    - OAuth:
-        - vault
-        - vault:instruments
-    - ApiSecretKey: []
-  summary: Delete an instrument
-  description: |
-    Delete a payment instrument.
-  parameters:
-    - in: path
-      name: id
+  patch:
+    tags:
+      - Instruments
+    security:
+      - OAuth:
+          - vault
+          - vault:instruments
+      - ApiSecretKey: []
+    summary: Update an instrument
+    description: |
+      Update the details of a payment instrument.
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          pattern: '^(src_)[a-z0-9]{26}$'
+        example: src_ubfj2q76miwundwlk72vxt2i7q
+        description: The instrument ID
+    requestBody:
       required: true
-      schema:
-        type: string
-        pattern: '^(src_)[a-z0-9]{26}$'
-      example: src_ubfj2q76miwundwlk72vxt2i7q
-      description: The ID of the payment instrument to be deleted
-  responses:
-    '204':
-      description: Instrument deleted successfully
-    '401':
-      description: Unauthorized
-    '404':
-      description: Instrument not found or not associated with client
-    '500':
-      description: Internal Error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/UpdateInstrumentRequest'
+    responses:
+      '200':
+        description: Instrument updated successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateInstrumentResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Instrument not found or not associated with client
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '500':
+        description: Internal Error
+
+  delete:
+    tags:
+      - Instruments
+    security:
+      - OAuth:
+          - vault
+          - vault:instruments
+      - ApiSecretKey: []
+    summary: Delete an instrument
+    description: |
+      Delete a payment instrument.
+    parameters:
+      - in: path
+        name: id
+        required: true
+        schema:
+          type: string
+          pattern: '^(src_)[a-z0-9]{26}$'
+        example: src_ubfj2q76miwundwlk72vxt2i7q
+        description: The ID of the payment instrument to be deleted
+    responses:
+      '204':
+        description: Instrument deleted successfully
+      '401':
+        description: Unauthorized
+      '404':
+        description: Instrument not found or not associated with client
+      '500':
+        description: Internal Error

--- a/nas_spec/paths/marketplace@entities.yaml
+++ b/nas_spec/paths/marketplace@entities.yaml
@@ -1,121 +1,122 @@
-post:
-  description: |
-    Onboard a sub-entity so they can start receiving payments. Once created, Checkout.com will run due diligence checks. 
-    If the checks are successful, we'll enable payment capabilities for that sub-entity and they will start receiving payments.
-  summary: Onboard a sub-entity
-  requestBody:
-    required: true
-    description: The sub-entity to be onboarded.
-    content:
-      application/json:
-        schema:
-          $ref: '#/components/schemas/EntityCreateRequest'
-        examples:
-          Company:
-            value:
-              reference: superhero1234
-              contact_details:
-                phone:
-                  number: '2345678910'
-              profile:
-                urls:
-                  - https://www.superheroexample.com
-                mccs:
-                  - '5669'
-              company:
-                business_registration_number: '452349600005'
-                legal_name: 'Super Hero Masks Inc.'
-                trading_name: 'Super Hero Masks'
-                principal_address:
-                  address_line1: '90 Tottenham Court Road'
-                  city: 'London'
-                  zip: 'W1T4TJ'
-                  country: 'GB'
-                registered_address:
-                  address_line1: '90 Tottenham Court Road'
-                  city: 'London'
-                  zip: 'W1T4TJ'
-                  country: 'GB'
-                representatives:
-                  - first_name: 'John'
-                    last_name: 'Doe'
-                    address:
-                      address_line1: '90 Tottenham Court Road'
-                      city: 'London'
-                      zip: 'W1T4TJ'
-                      country: 'GB'
-                    identification:
-                      national_id_number: 'AB123456C'
-                    phone:
-                      number: '2345678910'
-                    date_of_birth:
-                      day: 05
-                      month: 06
-                      year: 1995
-          Individual:
-            value:
-              reference: superhero1234
-              contact_details:
-                phone:
-                  number: '2345678910'
-              profile:
-                urls:
-                  - https://www.superheroexample.com
-                mccs:
-                  - '5669'
-              individual:
-                first_name: 'John'
-                last_name: 'Doe'
-                trading_name: "John's Super Hero Masks"
-                registered_address:
-                  address_line1: '90 Tottenham Court Road'
-                  city: 'London'
-                  zip: 'W1T4TJ'
-                  country: 'GB'
-                national_tax_id: 'TAX123456'
-                date_of_birth:
-                  day: 05
-                  month: 06
-                  year: 1995
-                identification:
-                  national_id_number: 'AB123456C'
-  security:
-    - OAuth:
-        - marketplace
-  responses:
-    '201':
-      description: Sub-entity onboarded successfully
+/marketplace/entities:
+  post:
+    description: |
+      Onboard a sub-entity so they can start receiving payments. Once created, Checkout.com will run due diligence checks.
+      If the checks are successful, we'll enable payment capabilities for that sub-entity and they will start receiving payments.
+    summary: Onboard a sub-entity
+    requestBody:
+      required: true
+      description: The sub-entity to be onboarded.
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/EntityBasicResponseWithLinks'
-      headers:
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-    '400':
-      description: Bad Request
-    '401':
-      description: Unauthorized
-    '409':
-      description: Sub-entity onboarding request conflicted with an existing sub-entity
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/EntityLinks'
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: '#/components/schemas/ValidationError'
-              - type: object
-                properties:
-                  error_codes:
-                    example:
-                      - error_code1
-                      - error_code2
-  tags:
-    - Marketplace
+            $ref: '#/components/schemas/EntityCreateRequest'
+          examples:
+            Company:
+              value:
+                reference: superhero1234
+                contact_details:
+                  phone:
+                    number: '2345678910'
+                profile:
+                  urls:
+                    - https://www.superheroexample.com
+                  mccs:
+                    - '5669'
+                company:
+                  business_registration_number: '452349600005'
+                  legal_name: 'Super Hero Masks Inc.'
+                  trading_name: 'Super Hero Masks'
+                  principal_address:
+                    address_line1: '90 Tottenham Court Road'
+                    city: 'London'
+                    zip: 'W1T4TJ'
+                    country: 'GB'
+                  registered_address:
+                    address_line1: '90 Tottenham Court Road'
+                    city: 'London'
+                    zip: 'W1T4TJ'
+                    country: 'GB'
+                  representatives:
+                    - first_name: 'John'
+                      last_name: 'Doe'
+                      address:
+                        address_line1: '90 Tottenham Court Road'
+                        city: 'London'
+                        zip: 'W1T4TJ'
+                        country: 'GB'
+                      identification:
+                        national_id_number: 'AB123456C'
+                      phone:
+                        number: '2345678910'
+                      date_of_birth:
+                        day: 05
+                        month: 06
+                        year: 1995
+            Individual:
+              value:
+                reference: superhero1234
+                contact_details:
+                  phone:
+                    number: '2345678910'
+                profile:
+                  urls:
+                    - https://www.superheroexample.com
+                  mccs:
+                    - '5669'
+                individual:
+                  first_name: 'John'
+                  last_name: 'Doe'
+                  trading_name: "John's Super Hero Masks"
+                  registered_address:
+                    address_line1: '90 Tottenham Court Road'
+                    city: 'London'
+                    zip: 'W1T4TJ'
+                    country: 'GB'
+                  national_tax_id: 'TAX123456'
+                  date_of_birth:
+                    day: 05
+                    month: 06
+                    year: 1995
+                  identification:
+                    national_id_number: 'AB123456C'
+    security:
+      - OAuth:
+          - marketplace
+    responses:
+      '201':
+        description: Sub-entity onboarded successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EntityBasicResponseWithLinks'
+        headers:
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+      '400':
+        description: Bad Request
+      '401':
+        description: Unauthorized
+      '409':
+        description: Sub-entity onboarding request conflicted with an existing sub-entity
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EntityLinks'
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/ValidationError'
+                - type: object
+                  properties:
+                    error_codes:
+                      example:
+                        - error_code1
+                        - error_code2
+    tags:
+      - Marketplace

--- a/nas_spec/paths/marketplace@entities@{id}.yaml
+++ b/nas_spec/paths/marketplace@entities@{id}.yaml
@@ -1,38 +1,172 @@
-parameters:
-  - in: path
-    name: id
-    description: The ID of the sub-entity.
+/marketplace/entities/{id}:
+  parameters:
+    - in: path
+      name: id
+      description: The ID of the sub-entity.
 
-    required: true
-    allowEmptyValue: false
-    example: ent_w4jelhppmfiufdnatam37wrfc4
-    style: simple
-    schema:
-      type: string
-get:
-  description: Use this endpoint to retrieve a sub-entity and its full details.
-  summary: Get sub-entity details
-  security:
-    - OAuth:
-        - marketplace
-  responses:
-    '200':
-      description: Sub-entity retrieved successfully
+      required: true
+      allowEmptyValue: false
+      example: ent_w4jelhppmfiufdnatam37wrfc4
+      style: simple
+      schema:
+        type: string
+  get:
+    description: Use this endpoint to retrieve a sub-entity and its full details.
+    summary: Get sub-entity details
+    security:
+      - OAuth:
+          - marketplace
+    responses:
+      '200':
+        description: Sub-entity retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EntityExtendedResponse'
+            examples:
+              Company:
+                value:
+                  id: ent_wxglze3wwywujg4nna5fb7ldli
+                  reference: superhero1234
+                  capabilities:
+                    payments:
+                      enabled: false
+                    payouts:
+                      enabled: false
+                  status: pending
+                  contact_details:
+                    phone:
+                      number: '2345678910'
+                  profile:
+                    urls:
+                      - https://www.superheroexample.com
+                    mccs:
+                      - '5669'
+                  company:
+                    business_registration_number: '452349600005'
+                    legal_name: Super Hero Masks Inc.
+                    trading_name: Super Hero Masks
+                    principal_address:
+                      address_line1: 90 Tottenham Court Road
+                      city: London
+                      zip: W1T4TJ
+                      country: GB
+                    registered_address:
+                      address_line1: 90 Tottenham Court Road
+                      city: London
+                      zip: W1T4TJ
+                      country: GB
+                    representatives:
+                      - first_name: John
+                        middle_name:
+                        last_name: Doe
+                        address:
+                          address_line1: 90 Tottenham Court Road
+                          city: London
+                          zip: W1T4TJ
+                          country: GB
+                        identification:
+                          national_id_number: 'AB123456C'
+                          document:
+                            type: 'driving_license'
+                            front: 'file_wxglze3wwywujg4nna5fb7ldli'
+                            back: 'file_adglze3wwywujg4nna5fb7l1sg'
+                        phone:
+                          number: '2345678910'
+                        date_of_birth:
+                          day: 05
+                          month: 06
+                          year: 1995
+                  instruments:
+                    - id: src_hmnkhxlshf3uhljow7zt7sf2cq
+                      label: Peter's Personal Account
+                  _links:
+                    self:
+                      href: https://api.checkout.com/marketplace/entities/ent_wxglze3wwywujg4nna5fb7ldli
+              Individual:
+                value:
+                  id: ent_wxglze3wwywujg4nna5fb7ldli
+                  reference: superhero1234
+                  capabilities:
+                    payments:
+                      enabled: false
+                    payouts:
+                      enabled: false
+                  contact_details:
+                    phone:
+                      number: '2345678910'
+                  profile:
+                    urls:
+                      - https://www.superheroexample.com
+                    mccs:
+                      - '5669'
+                  individual:
+                    first_name: John
+                    middle_name: Paul
+                    last_name: Doe
+                    trading_name: Super Hero Masks
+                    legal_name: John Paul Doe
+                    national_tax_id: '1234567'
+                    registered_address:
+                      address_line1: 90 Tottenham Court Road
+                      city: London
+                      zip: W1T4TJ
+                      country: GB
+                    date_of_birth:
+                      day: 05
+                      month: 06
+                      year: 1995
+                    identification:
+                      national_id_number: 'AB123456C'
+                      document:
+                        type: 'driving_license'
+                        front: 'file_wxglze3wwywujg4nna5fb7ldli'
+                        back: 'file_adglze3wwywujg4nna5fb7l1sg'
+                  instruments:
+                    - id: src_hmnkhxlshf3uhljow7zt7sf2cq
+                      label: Peter's Personal Account
+                  _links:
+                    self:
+                      href: https://api.checkout.com/marketplace/entities/ent_wxglze3wwywujg4nna5fb7ldli
+        headers:
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Sub-entity not found
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/ValidationError'
+                - type: object
+                  properties:
+                    error_codes:
+                      example:
+                        - error_code1
+                        - error_code2
+    tags:
+      - Marketplace
+  put:
+    description: |
+      You can update all fields under the Contact details, Profile, and Company objects. You can also add <strong>identification</strong> information to complete due diligence requirements.<br><br>
+      <strong>Note:</strong> when you update a sub-entity we may conduct further due diligence checks when necessary. During these checks, your payment capabilities will remain the same.
+    summary: Update sub-entity details
+    requestBody:
+      required: true
+      description: The sub-entity to be updated.
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/EntityExtendedResponse'
+            $ref: '#/components/schemas/EntityUpdateRequest'
           examples:
             Company:
               value:
-                id: ent_wxglze3wwywujg4nna5fb7ldli
-                reference: superhero1234
-                capabilities:
-                  payments:
-                    enabled: false
-                  payouts:
-                    enabled: false
-                status: pending
                 contact_details:
                   phone:
                     number: '2345678910'
@@ -43,54 +177,36 @@ get:
                     - '5669'
                 company:
                   business_registration_number: '452349600005'
-                  legal_name: Super Hero Masks Inc.
-                  trading_name: Super Hero Masks
+                  legal_name: 'Super Hero Masks Inc.'
+                  trading_name: 'Super Hero Masks'
                   principal_address:
-                    address_line1: 90 Tottenham Court Road
-                    city: London
-                    zip: W1T4TJ
-                    country: GB
+                    address_line1: '90 Tottenham Court Road'
+                    city: 'London'
+                    zip: 'W1T4TJ'
+                    country: 'GB'
                   registered_address:
-                    address_line1: 90 Tottenham Court Road
-                    city: London
-                    zip: W1T4TJ
-                    country: GB
+                    address_line1: '90 Tottenham Court Road'
+                    city: 'London'
+                    zip: 'W1T4TJ'
+                    country: 'GB'
                   representatives:
-                    - first_name: John
-                      middle_name:
-                      last_name: Doe
+                    - first_name: 'John'
+                      last_name: 'Doe'
                       address:
-                        address_line1: 90 Tottenham Court Road
-                        city: London
-                        zip: W1T4TJ
-                        country: GB
+                        address_line1: '90 Tottenham Court Road'
+                        city: 'London'
+                        zip: 'W1T4TJ'
+                        country: 'GB'
                       identification:
                         national_id_number: 'AB123456C'
-                        document:
-                          type: 'driving_license'
-                          front: 'file_wxglze3wwywujg4nna5fb7ldli'
-                          back: 'file_adglze3wwywujg4nna5fb7l1sg'
                       phone:
                         number: '2345678910'
                       date_of_birth:
                         day: 05
                         month: 06
                         year: 1995
-                instruments:
-                  - id: src_hmnkhxlshf3uhljow7zt7sf2cq
-                    label: Peter's Personal Account
-                _links:
-                  self:
-                    href: https://api.checkout.com/marketplace/entities/ent_wxglze3wwywujg4nna5fb7ldli
             Individual:
               value:
-                id: ent_wxglze3wwywujg4nna5fb7ldli
-                reference: superhero1234
-                capabilities:
-                  payments:
-                    enabled: false
-                  payouts:
-                    enabled: false
                 contact_details:
                   phone:
                     number: '2345678910'
@@ -100,167 +216,52 @@ get:
                   mccs:
                     - '5669'
                 individual:
-                  first_name: John
-                  middle_name: Paul
-                  last_name: Doe
-                  trading_name: Super Hero Masks
-                  legal_name: John Paul Doe
-                  national_tax_id: '1234567'
+                  first_name: 'John'
+                  last_name: 'Doe'
+                  trading_name: "John's Super Hero Masks"
                   registered_address:
-                    address_line1: 90 Tottenham Court Road
-                    city: London
-                    zip: W1T4TJ
-                    country: GB
+                    address_line1: '90 Tottenham Court Road'
+                    city: 'London'
+                    zip: 'W1T4TJ'
+                    country: 'GB'
+                  national_tax_id: 'TAX123456'
                   date_of_birth:
                     day: 05
                     month: 06
                     year: 1995
                   identification:
                     national_id_number: 'AB123456C'
-                    document:
-                      type: 'driving_license'
-                      front: 'file_wxglze3wwywujg4nna5fb7ldli'
-                      back: 'file_adglze3wwywujg4nna5fb7l1sg'
-                instruments:
-                  - id: src_hmnkhxlshf3uhljow7zt7sf2cq
-                    label: Peter's Personal Account
-                _links:
-                  self:
-                    href: https://api.checkout.com/marketplace/entities/ent_wxglze3wwywujg4nna5fb7ldli
-      headers:
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Sub-entity not found
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: '#/components/schemas/ValidationError'
-              - type: object
-                properties:
-                  error_codes:
-                    example:
-                      - error_code1
-                      - error_code2
-  tags:
-    - Marketplace
-put:
-  description: |
-    You can update all fields under the Contact details, Profile, and Company objects. You can also add <strong>identification</strong> information to complete due diligence requirements.<br><br>
-    <strong>Note:</strong> when you update a sub-entity we may conduct further due diligence checks when necessary. During these checks, your payment capabilities will remain the same.
-  summary: Update sub-entity details
-  requestBody:
-    required: true
-    description: The sub-entity to be updated.
-    content:
-      application/json:
-        schema:
-          $ref: '#/components/schemas/EntityUpdateRequest'
-        examples:
-          Company:
-            value:
-              contact_details:
-                phone:
-                  number: '2345678910'
-              profile:
-                urls:
-                  - https://www.superheroexample.com
-                mccs:
-                  - '5669'
-              company:
-                business_registration_number: '452349600005'
-                legal_name: 'Super Hero Masks Inc.'
-                trading_name: 'Super Hero Masks'
-                principal_address:
-                  address_line1: '90 Tottenham Court Road'
-                  city: 'London'
-                  zip: 'W1T4TJ'
-                  country: 'GB'
-                registered_address:
-                  address_line1: '90 Tottenham Court Road'
-                  city: 'London'
-                  zip: 'W1T4TJ'
-                  country: 'GB'
-                representatives:
-                  - first_name: 'John'
-                    last_name: 'Doe'
-                    address:
-                      address_line1: '90 Tottenham Court Road'
-                      city: 'London'
-                      zip: 'W1T4TJ'
-                      country: 'GB'
-                    identification:
-                      national_id_number: 'AB123456C'
-                    phone:
-                      number: '2345678910'
-                    date_of_birth:
-                      day: 05
-                      month: 06
-                      year: 1995
-          Individual:
-            value:
-              contact_details:
-                phone:
-                  number: '2345678910'
-              profile:
-                urls:
-                  - https://www.superheroexample.com
-                mccs:
-                  - '5669'
-              individual:
-                first_name: 'John'
-                last_name: 'Doe'
-                trading_name: "John's Super Hero Masks"
-                registered_address:
-                  address_line1: '90 Tottenham Court Road'
-                  city: 'London'
-                  zip: 'W1T4TJ'
-                  country: 'GB'
-                national_tax_id: 'TAX123456'
-                date_of_birth:
-                  day: 05
-                  month: 06
-                  year: 1995
-                identification:
-                  national_id_number: 'AB123456C'
-  security:
-    - OAuth:
-        - marketplace
-  responses:
-    '200':
-      description: Sub-entity updated successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/EntityBasicResponseWithLinks'
-      headers:
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Sub-entity not found
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: '#/components/schemas/ValidationError'
-              - type: object
-                properties:
-                  error_codes:
-                    example:
-                      - error_code1
-                      - error_code2
-  tags:
-    - Marketplace
+    security:
+      - OAuth:
+          - marketplace
+    responses:
+      '200':
+        description: Sub-entity updated successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EntityBasicResponseWithLinks'
+        headers:
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Sub-entity not found
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/ValidationError'
+                - type: object
+                  properties:
+                    error_codes:
+                      example:
+                        - error_code1
+                        - error_code2
+    tags:
+      - Marketplace

--- a/nas_spec/paths/marketplace@entities@{id}@instruments.yaml
+++ b/nas_spec/paths/marketplace@entities@{id}@instruments.yaml
@@ -1,71 +1,72 @@
-parameters:
-  - in: path
-    name: id
-    description: The ID of the sub-entity.
-    required: true
-    allowEmptyValue: false
-    example: ent_w4jelhppmfiufdnatam37wrfc4
-    style: simple
-    schema:
-      type: string
-post:
-  description: Create a bank account payment instrument for your sub-entity that you can later use as the destination for their payouts.
-  summary: Add a payment instrument
-  requestBody:
-    required: true
-    description: A JSON payload containing the payment instrument details.
-    content:
-      application/json:
-        schema:
-          $ref: '#/components/schemas/MarketplaceInstrumentCreateRequest'
-        examples:
-          BankAccount:
-            value:
-              label: Peter's Personal Account
-              type: bank_account
-              account_number: '12345678'
-              bank_code: '050389'
-              currency: GBP
-              country: GB
-              account_holder:
-                first_name: Peter
-                last_name: Parker
-                billing_address:
-                  address_line1: 90 Tottenham Court Road
-                  city: London
-                  state: London
-                  zip: W1T 4TJ
-                  country: GB
-              document:
-                type: bank_statement
-                file_id: file_wxglze3wwywujg4nna5fb7ldli
-  security:
-    - OAuth:
-        - marketplace
-  responses:
-    '202':
-      description: Instrument creation request accepted
-      headers:
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-    '400':
-      description: Bad Request
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
+/marketplace/entities/{id}/instruments:
+  parameters:
+    - in: path
+      name: id
+      description: The ID of the sub-entity.
+      required: true
+      allowEmptyValue: false
+      example: ent_w4jelhppmfiufdnatam37wrfc4
+      style: simple
+      schema:
+        type: string
+  post:
+    description: Create a bank account payment instrument for your sub-entity that you can later use as the destination for their payouts.
+    summary: Add a payment instrument
+    requestBody:
+      required: true
+      description: A JSON payload containing the payment instrument details.
       content:
         application/json:
           schema:
-            allOf:
-              - $ref: '#/components/schemas/ValidationError'
-              - type: object
-                properties:
-                  error_codes:
-                    example:
-                      - error_code1
-                      - error_code2
-  tags:
-    - Marketplace
+            $ref: '#/components/schemas/MarketplaceInstrumentCreateRequest'
+          examples:
+            BankAccount:
+              value:
+                label: Peter's Personal Account
+                type: bank_account
+                account_number: '12345678'
+                bank_code: '050389'
+                currency: GBP
+                country: GB
+                account_holder:
+                  first_name: Peter
+                  last_name: Parker
+                  billing_address:
+                    address_line1: 90 Tottenham Court Road
+                    city: London
+                    state: London
+                    zip: W1T 4TJ
+                    country: GB
+                document:
+                  type: bank_statement
+                  file_id: file_wxglze3wwywujg4nna5fb7ldli
+    security:
+      - OAuth:
+          - marketplace
+    responses:
+      '202':
+        description: Instrument creation request accepted
+        headers:
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+      '400':
+        description: Bad Request
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              allOf:
+                - $ref: '#/components/schemas/ValidationError'
+                - type: object
+                  properties:
+                    error_codes:
+                      example:
+                        - error_code1
+                        - error_code2
+    tags:
+      - Marketplace

--- a/nas_spec/paths/payments.yaml
+++ b/nas_spec/paths/payments.yaml
@@ -1,199 +1,200 @@
-post:
-  security:
-    - OAuth:
-        - gateway
-        - gateway:payment
-    - ApiSecretKey: []
-  tags:
-    - Payments
-  summary: Request a payment or payout
-  operationId: requestAPaymentOrPayout
-  description: |
-    Send a payment or payout.<br><br><b>Note</b>: successful payout requests will always return a 202 response.
-  parameters:
-    - $ref: '#/components/parameters/ckoIdempotencyKey'
-  requestBody:
-    content:
-      application/json:
-        schema:
-          oneOf:
-            - $ref: '#/components/schemas/PaymentRequest'
-            - $ref: '#/components/schemas/PayoutRequest'
-        examples:
-          Payment:
-            value:
-              source:
-                type: token
-                token: tok_4gzeau5o2uqubbk6fufs3m7p54
-              amount: 6540
-              currency: USD
-              payment_type: Recurring
-              reference: 'ORD-5023-4E89'
-              description: 'Set of 3 masks'
-              capture: true
-              capture_on: '2019-09-10T10:11:12Z'
-              customer:
-                id: 'cus_udst2tfldj6upmye2reztkmm4i'
-                email: 'brucewayne@gmail.com'
-                name: 'Bruce Wayne'
-              billing_descriptor:
-                name: SUPERHEROES.COM
-                city: GOTHAM
-              shipping:
-                address:
-                  address_line1: Checkout.com
-                  address_line2: 90 Tottenham Court Road
-                  city: London
-                  state: London
-                  zip: W1T 4TJ
-                  country: GB
-                phone:
-                  country_code: '+1'
-                  number: 415 555 2671
-              3ds:
-                enabled: true
-                attempt_n3d: true
-                eci: '05'
-                cryptogram: AgAAAAAAAIR8CQrXcIhbQAAAAAA=
-                xid: MDAwMDAwMDAwMDAwMDAwMzIyNzY=
-                version: '2.0.1'
-              previous_payment_id: 'pay_fun26akvvjjerahhctaq2uzhu4'
-              risk:
-                enabled: false
-              success_url: 'http://example.com/payments/success'
-              failure_url: 'http://example.com/payments/fail'
-              payment_ip: '90.197.169.245'
-              recipient:
-                dob: '1985-05-15'
-                account_number: '5555554444'
-                zip: W1T
-                last_name: Jones
-              metadata:
-                coupon_code: 'NY2018'
-                partner_id: 123989
-          Payout:
-            value:
-              source:
-                type: 'currency_account'
-                id: 'ca_y3oqhf46pyzuxjbcn2giaqnb44'
-              destination:
-                type: 'id'
-                id: 'src_gsd2agaqd2sernz5tpcfv555nq'
-              amount: 1000
-              currency: GBP
-              reference: 'PO-215-5721'
-              billing_descriptor:
-                reference: 'Withdrawal'
-              sender:
-                type: 'instrument'
-                reference: '8285282045818'
-              instruction:
-                purpose: 'Withdrawal'
-                scheme: 'local'
-                quote_id: 'qte_mbabizu24mvu3mela5njyhpit4'
-              processing_channel_id: 'pc_hpswyyx23geezflc2ocz3exn4y'
-
-  responses:
-    '201':
-      description: Payment processed successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/PaymentResponse'
-          example:
-            id: 'pay_mbabizu24mvu3mela5njyhpit4'
-            action_id: 'act_mbabizu24mvu3mela5njyhpit4'
-            amount: 6540
-            currency: 'USD'
-            approved: true
-            status: 'Authorized'
-            auth_code: '770687'
-            response_code: '10000'
-            response_summary: 'Approved'
-            3ds:
-              downgraded: true
-              enrolled: 'N'
-            risk:
-              flagged: true
-            source:
-              type: 'card'
-              id: 'src_nwd3m4in3hkuddfpjsaevunhdy'
-              billing_address:
-                address_line1: 'Checkout.com'
-                address_line2: '90 Tottenham Court Road'
-                city: 'London'
-                state: 'London'
-                zip: 'W1T 4TJ'
-                country: 'GB'
-              phone:
-                country_code: '+1'
-                number: '415 555 2671'
-              last4: '4242'
-              fingerprint: 'F31828E2BDABAE63EB694903825CDD36041CC6ED461440B81415895855502832'
-              bin: '424242'
-            customer:
-              id: 'cus_udst2tfldj6upmye2reztkmm4i'
-              email: 'brucewayne@gmail.com'
-              name: 'Bruce Wayne'
-            processed_on: '2019-09-10T10:11:12Z'
-            reference: 'ORD-5023-4E89'
-            processing:
-              retrieval_reference_number: '909913440644'
-              acquirer_transaction_id: '440644309099499894406'
-            eci: '06'
-            scheme_id: '489341065491658'
-            _links:
-              self:
-                href: 'https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4'
-              action:
-                href: 'https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/actions'
-              void:
-                href: 'https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/captures'
-              capture:
-                href: 'https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/voids'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '202':
-      description: Payment asynchronous or further action required
+/payments:
+  post:
+    security:
+      - OAuth:
+          - gateway
+          - gateway:payment
+      - ApiSecretKey: []
+    tags:
+      - Payments
+    summary: Request a payment or payout
+    operationId: requestAPaymentOrPayout
+    description: |
+      Send a payment or payout.<br><br><b>Note</b>: successful payout requests will always return a 202 response.
+    parameters:
+      - $ref: '#/components/parameters/ckoIdempotencyKey'
+    requestBody:
       content:
         application/json:
           schema:
             oneOf:
-              - $ref: '#/components/schemas/PaymentAcceptedResponse'
-              - $ref: '#/components/schemas/PayoutAcceptedResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '429':
-      description: Too many requests or duplicate request detected
-      content:
-        application/json:
-          schema:
-            type: object
-            properties:
-              request_id:
-                type: string
-                example: 0HL80RJLS76I7
-              error_type:
-                type: string
-                example: request_invalid
-              error_codes:
-                type: array
-                items:
+              - $ref: '#/components/schemas/PaymentRequest'
+              - $ref: '#/components/schemas/PayoutRequest'
+          examples:
+            Payment:
+              value:
+                source:
+                  type: token
+                  token: tok_4gzeau5o2uqubbk6fufs3m7p54
+                amount: 6540
+                currency: USD
+                payment_type: Recurring
+                reference: 'ORD-5023-4E89'
+                description: 'Set of 3 masks'
+                capture: true
+                capture_on: '2019-09-10T10:11:12Z'
+                customer:
+                  id: 'cus_udst2tfldj6upmye2reztkmm4i'
+                  email: 'brucewayne@gmail.com'
+                  name: 'Bruce Wayne'
+                billing_descriptor:
+                  name: SUPERHEROES.COM
+                  city: GOTHAM
+                shipping:
+                  address:
+                    address_line1: Checkout.com
+                    address_line2: 90 Tottenham Court Road
+                    city: London
+                    state: London
+                    zip: W1T 4TJ
+                    country: GB
+                  phone:
+                    country_code: '+1'
+                    number: 415 555 2671
+                3ds:
+                  enabled: true
+                  attempt_n3d: true
+                  eci: '05'
+                  cryptogram: AgAAAAAAAIR8CQrXcIhbQAAAAAA=
+                  xid: MDAwMDAwMDAwMDAwMDAwMzIyNzY=
+                  version: '2.0.1'
+                previous_payment_id: 'pay_fun26akvvjjerahhctaq2uzhu4'
+                risk:
+                  enabled: false
+                success_url: 'http://example.com/payments/success'
+                failure_url: 'http://example.com/payments/fail'
+                payment_ip: '90.197.169.245'
+                recipient:
+                  dob: '1985-05-15'
+                  account_number: '5555554444'
+                  zip: W1T
+                  last_name: Jones
+                metadata:
+                  coupon_code: 'NY2018'
+                  partner_id: 123989
+            Payout:
+              value:
+                source:
+                  type: 'currency_account'
+                  id: 'ca_y3oqhf46pyzuxjbcn2giaqnb44'
+                destination:
+                  type: 'id'
+                  id: 'src_gsd2agaqd2sernz5tpcfv555nq'
+                amount: 1000
+                currency: GBP
+                reference: 'PO-215-5721'
+                billing_descriptor:
+                  reference: 'Withdrawal'
+                sender:
+                  type: 'instrument'
+                  reference: '8285282045818'
+                instruction:
+                  purpose: 'Withdrawal'
+                  scheme: 'local'
+                  quote_id: 'qte_mbabizu24mvu3mela5njyhpit4'
+                processing_channel_id: 'pc_hpswyyx23geezflc2ocz3exn4y'
+
+    responses:
+      '201':
+        description: Payment processed successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PaymentResponse'
+            example:
+              id: 'pay_mbabizu24mvu3mela5njyhpit4'
+              action_id: 'act_mbabizu24mvu3mela5njyhpit4'
+              amount: 6540
+              currency: 'USD'
+              approved: true
+              status: 'Authorized'
+              auth_code: '770687'
+              response_code: '10000'
+              response_summary: 'Approved'
+              3ds:
+                downgraded: true
+                enrolled: 'N'
+              risk:
+                flagged: true
+              source:
+                type: 'card'
+                id: 'src_nwd3m4in3hkuddfpjsaevunhdy'
+                billing_address:
+                  address_line1: 'Checkout.com'
+                  address_line2: '90 Tottenham Court Road'
+                  city: 'London'
+                  state: 'London'
+                  zip: 'W1T 4TJ'
+                  country: 'GB'
+                phone:
+                  country_code: '+1'
+                  number: '415 555 2671'
+                last4: '4242'
+                fingerprint: 'F31828E2BDABAE63EB694903825CDD36041CC6ED461440B81415895855502832'
+                bin: '424242'
+              customer:
+                id: 'cus_udst2tfldj6upmye2reztkmm4i'
+                email: 'brucewayne@gmail.com'
+                name: 'Bruce Wayne'
+              processed_on: '2019-09-10T10:11:12Z'
+              reference: 'ORD-5023-4E89'
+              processing:
+                retrieval_reference_number: '909913440644'
+                acquirer_transaction_id: '440644309099499894406'
+              eci: '06'
+              scheme_id: '489341065491658'
+              _links:
+                self:
+                  href: 'https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4'
+                action:
+                  href: 'https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/actions'
+                void:
+                  href: 'https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/captures'
+                capture:
+                  href: 'https://api.sandbox.checkout.com/payments/pay_mbabizu24mvu3mela5njyhpit4/voids'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '202':
+        description: Payment asynchronous or further action required
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/PaymentAcceptedResponse'
+                - $ref: '#/components/schemas/PayoutAcceptedResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '429':
+        description: Too many requests or duplicate request detected
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                request_id:
                   type: string
-                  example: duplicate_request
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '502':
-      description: Bad gateway
+                  example: 0HL80RJLS76I7
+                error_type:
+                  type: string
+                  example: request_invalid
+                error_codes:
+                  type: array
+                  items:
+                    type: string
+                    example: duplicate_request
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '502':
+        description: Bad gateway

--- a/nas_spec/paths/payments@{id}.yaml
+++ b/nas_spec/paths/payments@{id}.yaml
@@ -1,43 +1,44 @@
-get:
-  tags:
-    - Payments
-  security:
-    - OAuth:
-        - gateway
-        - gateway:payment-details
-    - ApiSecretKey: []
-  summary: Get payment details
-  description: |
-    Returns the details of the payment with the specified identifier string.
+/payments/{id}:
+  get:
+    tags:
+      - Payments
+    security:
+      - OAuth:
+          - gateway
+          - gateway:payment-details
+      - ApiSecretKey: []
+    summary: Get payment details
+    description: |
+      Returns the details of the payment with the specified identifier string.
 
-    If the payment method requires a redirection to a third party (e.g., 3D Secure),
-    the redirect URL back to your site will include a `cko-session-id` query parameter
-    containing a payment session ID that can be used to obtain the details of the payment, for example:
+      If the payment method requires a redirection to a third party (e.g., 3D Secure),
+      the redirect URL back to your site will include a `cko-session-id` query parameter
+      containing a payment session ID that can be used to obtain the details of the payment, for example:
 
-    http://example.com/success?cko-session-id=sid_ubfj2q76miwundwlk72vxt2i7q.
-  parameters:
-    - in: path
-      name: id
-      schema:
-        type: string
-        pattern: "^(pay|sid)_(\\w{26})$"
-      required: true
-      description: The payment or payment session identifier
-  responses:
-    '200':
-      description: Payment retrieved successfully
-      content:
-        application/json:
-          schema:
-            oneOf:
-              - $ref: '#/components/schemas/PaymentDetails'
-              - $ref: '#/components/schemas/PayoutDetails'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Payment not found
+      http://example.com/success?cko-session-id=sid_ubfj2q76miwundwlk72vxt2i7q.
+    parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          pattern: "^(pay|sid)_(\\w{26})$"
+        required: true
+        description: The payment or payment session identifier
+    responses:
+      '200':
+        description: Payment retrieved successfully
+        content:
+          application/json:
+            schema:
+              oneOf:
+                - $ref: '#/components/schemas/PaymentDetails'
+                - $ref: '#/components/schemas/PayoutDetails'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Payment not found

--- a/nas_spec/paths/payments@{id}@actions.yaml
+++ b/nas_spec/paths/payments@{id}@actions.yaml
@@ -1,35 +1,36 @@
-get:
-  tags:
-    - Payments
-  security:
-    - OAuth:
-        - gateway
-        - gateway:payment-details
-    - ApiSecretKey: []
-  summary: Get payment actions
-  description: |
-    Returns all the actions associated with a payment ordered by processing date in descending order (latest first).
-  parameters:
-    - in: path
-      name: id
-      schema:
-        type: string
-        pattern: "^(pay)_(\\w{26})$"
-      required: true
-      description: The payment identifier
-  responses:
-    '200':
-      description: Payment actions retrieved successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/PaymentActionsResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Payment not found
+/payments/{id}/actions:
+  get:
+    tags:
+      - Payments
+    security:
+      - OAuth:
+          - gateway
+          - gateway:payment-details
+      - ApiSecretKey: []
+    summary: Get payment actions
+    description: |
+      Returns all the actions associated with a payment ordered by processing date in descending order (latest first).
+    parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+          pattern: "^(pay)_(\\w{26})$"
+        required: true
+        description: The payment identifier
+    responses:
+      '200':
+        description: Payment actions retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PaymentActionsResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Payment not found

--- a/nas_spec/paths/payments@{id}@authorizations.yaml
+++ b/nas_spec/paths/payments@{id}@authorizations.yaml
@@ -1,51 +1,52 @@
-post:
-  tags:
-    - Payments
-  security:
-    - OAuth:
-        - gateway
-        - gateway:payment-authorizations
-    - ApiSecretKey: []
-  summary: Increment authorization
-  description: |
-    Request an incremental authorization to increase the authorization amount or extend the authorization's validity period.
+/payments/{id}/authorizations:
+  post:
+    tags:
+      - Payments
+    security:
+      - OAuth:
+          - gateway
+          - gateway:payment-authorizations
+      - ApiSecretKey: []
+    summary: Increment authorization
+    description: |
+      Request an incremental authorization to increase the authorization amount or extend the authorization's validity period.
 
-  parameters:
-    - in: path
-      name: id
-      schema:
-        type: string
-        pattern: "^(pay)_(\\w{26})$"
-      required: true
-      description: The payment identifier
-  requestBody:
-    content:
-      application/json:
+    parameters:
+      - in: path
+        name: id
         schema:
-          $ref: '#/components/schemas/AuthorizationRequest'
-  responses:
-    '201':
-      description: Authorization processed successfully
+          type: string
+          pattern: "^(pay)_(\\w{26})$"
+        required: true
+        description: The payment identifier
+    requestBody:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/AuthorizationResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '403':
-      description: Capture not allowed
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '404':
-      description: Payment not found
-    '502':
-      description: Bad gateway
+            $ref: '#/components/schemas/AuthorizationRequest'
+    responses:
+      '201':
+        description: Authorization processed successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuthorizationResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '403':
+        description: Capture not allowed
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '404':
+        description: Payment not found
+      '502':
+        description: Bad gateway

--- a/nas_spec/paths/payments@{id}@captures.yaml
+++ b/nas_spec/paths/payments@{id}@captures.yaml
@@ -1,52 +1,53 @@
-post:
-  tags:
-    - Payments
-  security:
-    - OAuth:
-        - gateway
-        - gateway:payment-captures
-    - ApiSecretKey: []
-  summary: Capture a payment
-  description: |
-    Captures a payment if supported by the payment method.
+/payments/{id}/captures:
+  post:
+    tags:
+      - Payments
+    security:
+      - OAuth:
+          - gateway
+          - gateway:payment-captures
+      - ApiSecretKey: []
+    summary: Capture a payment
+    description: |
+      Captures a payment if supported by the payment method.
 
-    For card payments, capture requests are processed asynchronously. You can use [workflows](#tag/Workflows) to be notified if the capture is successful.
-  parameters:
-    - in: path
-      name: id
-      schema:
-        type: string
-        pattern: "^(pay)_(\\w{26})$"
-      required: true
-      description: The payment identifier
-  requestBody:
-    content:
-      application/json:
+      For card payments, capture requests are processed asynchronously. You can use [workflows](#tag/Workflows) to be notified if the capture is successful.
+    parameters:
+      - in: path
+        name: id
         schema:
-          $ref: '#/components/schemas/CaptureRequest'
-  responses:
-    '202':
-      description: Capture accepted
+          type: string
+          pattern: "^(pay)_(\\w{26})$"
+        required: true
+        description: The payment identifier
+    requestBody:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/CaptureAcceptedResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '403':
-      description: Capture not allowed
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '404':
-      description: Payment not found
-    '502':
-      description: Bad gateway
+            $ref: '#/components/schemas/CaptureRequest'
+    responses:
+      '202':
+        description: Capture accepted
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CaptureAcceptedResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '403':
+        description: Capture not allowed
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '404':
+        description: Payment not found
+      '502':
+        description: Bad gateway

--- a/nas_spec/paths/payments@{id}@refunds.yaml
+++ b/nas_spec/paths/payments@{id}@refunds.yaml
@@ -1,52 +1,53 @@
-post:
-  tags:
-    - Payments
-  security:
-    - OAuth:
-        - gateway
-        - gateway:payment-refunds
-    - ApiSecretKey: []
-  summary: Refund a payment
-  description: |
-    Refunds a payment if supported by the payment method.
+/payments/{id}/refunds:
+  post:
+    tags:
+      - Payments
+    security:
+      - OAuth:
+          - gateway
+          - gateway:payment-refunds
+      - ApiSecretKey: []
+    summary: Refund a payment
+    description: |
+      Refunds a payment if supported by the payment method.
 
-    For card payments, refund requests are processed asynchronously. You can use [workflows](#tag/Workflows) to be notified if the refund is successful.
-  parameters:
-    - in: path
-      name: id
-      schema:
-        type: string
-        pattern: "^(pay)_(\\w{26})$"
-      required: true
-      description: The payment identifier
-  requestBody:
-    content:
-      application/json:
+      For card payments, refund requests are processed asynchronously. You can use [workflows](#tag/Workflows) to be notified if the refund is successful.
+    parameters:
+      - in: path
+        name: id
         schema:
-          $ref: '#/components/schemas/RefundRequest'
-  responses:
-    '202':
-      description: Refund accepted
+          type: string
+          pattern: "^(pay)_(\\w{26})$"
+        required: true
+        description: The payment identifier
+    requestBody:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/RefundAcceptedResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '403':
-      description: Refund not allowed
-    '404':
-      description: Payment not found
-    '502':
-      description: Bad gateway
+            $ref: '#/components/schemas/RefundRequest'
+    responses:
+      '202':
+        description: Refund accepted
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RefundAcceptedResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '403':
+        description: Refund not allowed
+      '404':
+        description: Payment not found
+      '502':
+        description: Bad gateway

--- a/nas_spec/paths/payments@{id}@voids.yaml
+++ b/nas_spec/paths/payments@{id}@voids.yaml
@@ -1,52 +1,53 @@
-post:
-  tags:
-    - Payments
-  security:
-    - OAuth:
-        - gateway
-        - gateway:payment-voids
-    - ApiSecretKey: []
-  summary: Void a payment
-  description: |
-    Voids a payment if supported by the payment method.
+/payments/{id}/voids:
+  post:
+    tags:
+      - Payments
+    security:
+      - OAuth:
+          - gateway
+          - gateway:payment-voids
+      - ApiSecretKey: []
+    summary: Void a payment
+    description: |
+      Voids a payment if supported by the payment method.
 
-    For card payments, void requests are processed asynchronously. You can use [workflows](#tag/Workflows) to be notified if the void is successful.
-  parameters:
-    - in: path
-      name: id
-      schema:
-        type: string
-        pattern: "^(pay)_(\\w{26})$"
-      required: true
-      description: The payment identifier
-  requestBody:
-    content:
-      application/json:
+      For card payments, void requests are processed asynchronously. You can use [workflows](#tag/Workflows) to be notified if the void is successful.
+    parameters:
+      - in: path
+        name: id
         schema:
-          $ref: '#/components/schemas/VoidRequest'
-  responses:
-    '202':
-      description: Void accepted
+          type: string
+          pattern: "^(pay)_(\\w{26})$"
+        required: true
+        description: The payment identifier
+    requestBody:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/VoidAcceptedResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '403':
-      description: Void not allowed
-    '404':
-      description: Payment not found
-    '502':
-      description: Bad gateway
+            $ref: '#/components/schemas/VoidRequest'
+    responses:
+      '202':
+        description: Void accepted
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VoidAcceptedResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '403':
+        description: Void not allowed
+      '404':
+        description: Payment not found
+      '502':
+        description: Bad gateway

--- a/nas_spec/paths/risk@assessments@pre-authentication.yaml
+++ b/nas_spec/paths/risk@assessments@pre-authentication.yaml
@@ -1,49 +1,50 @@
-post:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Risk
-  summary: Request a pre-authentication risk scan
-  operationId: preAuthenticationRiskAssessment
-  description: |
-    Perform a pre-authentication fraud assessment using your defined risk settings.
-  #parameters:
-   # - $ref: '#/components/parameters/ckoIdempotencyKey'
-  requestBody:
-    content:
-      application/json:
-        schema:
-          $ref: '#/components/schemas/PreAuthenticationAssessmentRequest'
-  responses:
-  #   '200':
-  #     description: Transaction already assessed
-  #     content:
-  #       application/json:
-  #         schema:
-  #           $ref: '#/components/schemas/PreAuthenticationAssessmentResponse'
-  #       Cko-Request-Id:
-  #         $ref: "#/components/headers/Cko-Request-Id"
-  #       Cko-Version:
-  #         $ref: "#/components/headers/Cko-Version"
-    '201':
-      description: Transaction assessed successfully
+/risk/assessments/pre-authentication:
+  post:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Risk
+    summary: Request a pre-authentication risk scan
+    operationId: preAuthenticationRiskAssessment
+    description: |
+      Perform a pre-authentication fraud assessment using your defined risk settings.
+    #parameters:
+     # - $ref: '#/components/parameters/ckoIdempotencyKey'
+    requestBody:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/PreAuthenticationAssessmentResponse'
-        Cko-Request-Id:
-          schema:
-            $ref: "#/components/headers/Cko-Request-Id"
-        Cko-Version:
-          schema:
-            $ref: "#/components/headers/Cko-Version"
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '502':
-      description: Bad gateway
+            $ref: '#/components/schemas/PreAuthenticationAssessmentRequest'
+    responses:
+    #   '200':
+    #     description: Transaction already assessed
+    #     content:
+    #       application/json:
+    #         schema:
+    #           $ref: '#/components/schemas/PreAuthenticationAssessmentResponse'
+    #       Cko-Request-Id:
+    #         $ref: "#/components/headers/Cko-Request-Id"
+    #       Cko-Version:
+    #         $ref: "#/components/headers/Cko-Version"
+      '201':
+        description: Transaction assessed successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PreAuthenticationAssessmentResponse'
+          Cko-Request-Id:
+            schema:
+              $ref: "#/components/headers/Cko-Request-Id"
+          Cko-Version:
+            schema:
+              $ref: "#/components/headers/Cko-Version"
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '502':
+        description: Bad gateway

--- a/nas_spec/paths/risk@assessments@pre-capture.yaml
+++ b/nas_spec/paths/risk@assessments@pre-capture.yaml
@@ -1,51 +1,52 @@
-post:
-  security:
-    - ApiSecretKey: []
-  tags:
-    - Risk
-  summary: Request a pre-capture risk scan
-  operationId: preCaptureRiskAssessment
-  description: |
-    Perform a pre-capture fraud assessment using your defined risk settings.<br><br> **Note**: If you’ve already requested a pre-authentication fraud assessment for the transaction, provide the `assessment_id` returned in that response in your request to carry over the data. If you do include the `assessment_id`, the other fields you provide in this request will only fill in any gaps in the data; they will not overwrite any data.
-  # parameters:
-  #   - $ref: '#/components/parameters/ckoIdempotencyKey'
-  requestBody:
-    content:
-      application/json:
-        schema:
-          $ref: '#/components/schemas/PreCaptureAssessmentRequest'
-  responses:
-    '200':
-      description: Transaction already assessed
+/risk/assessments/pre-capture:
+  post:
+    security:
+      - ApiSecretKey: []
+    tags:
+      - Risk
+    summary: Request a pre-capture risk scan
+    operationId: preCaptureRiskAssessment
+    description: |
+      Perform a pre-capture fraud assessment using your defined risk settings.<br><br> **Note**: If you’ve already requested a pre-authentication fraud assessment for the transaction, provide the `assessment_id` returned in that response in your request to carry over the data. If you do include the `assessment_id`, the other fields you provide in this request will only fill in any gaps in the data; they will not overwrite any data.
+    # parameters:
+    #   - $ref: '#/components/parameters/ckoIdempotencyKey'
+    requestBody:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/PreCaptureAssessmentResponse'
-        Cko-Request-Id:
-          schema:
-            $ref: "#/components/headers/Cko-Request-Id"
-        Cko-Version:
-          schema:
-            $ref: "#/components/headers/Cko-Version"
-    '201':
-      description: Transaction assessed successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/PreCaptureAssessmentResponse'
-        Cko-Request-Id:
-          schema:
-            $ref: "#/components/headers/Cko-Request-Id"
-        Cko-Version:
-          schema:
-            $ref: "#/components/headers/Cko-Version"
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
-    '502':
-      description: Bad gateway
+            $ref: '#/components/schemas/PreCaptureAssessmentRequest'
+    responses:
+      '200':
+        description: Transaction already assessed
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PreCaptureAssessmentResponse'
+          Cko-Request-Id:
+            schema:
+              $ref: "#/components/headers/Cko-Request-Id"
+          Cko-Version:
+            schema:
+              $ref: "#/components/headers/Cko-Version"
+      '201':
+        description: Transaction assessed successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/PreCaptureAssessmentResponse'
+          Cko-Request-Id:
+            schema:
+              $ref: "#/components/headers/Cko-Request-Id"
+          Cko-Version:
+            schema:
+              $ref: "#/components/headers/Cko-Version"
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'
+      '502':
+        description: Bad gateway

--- a/nas_spec/paths/sessions.yaml
+++ b/nas_spec/paths/sessions.yaml
@@ -1,64 +1,65 @@
-post:
-  tags:
-    - Sessions
-  security:
-    - OAuth:
-        - sessions:app
-        - sessions:browser
-  summary: Request a session
-  description: |
-    Create a payment session to authenticate a cardholder before requesting a payment.
-    Payment sessions can be linked to one or more payments (in the case of recurring and other merchant-initiated payments).
+/sessions:
+  post:
+    tags:
+      - Sessions
+    security:
+      - OAuth:
+          - sessions:app
+          - sessions:browser
+    summary: Request a session
+    description: |
+      Create a payment session to authenticate a cardholder before requesting a payment.
+      Payment sessions can be linked to one or more payments (in the case of recurring and other merchant-initiated payments).
 
-    The `next_actions` object in the response tells you which actions can be performed next.
+      The `next_actions` object in the response tells you which actions can be performed next.
 
-  requestBody:
-    content:
-      application/json:
-        schema:
-          $ref: '#/components/schemas/SessionRequest'
-  responses:
-    '201':
-      description: Session processed successfully
+    requestBody:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/CreateSessionOkResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '202':
-      description: Session accepted and further action required
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/CreateSessionAcceptedResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '403':
-      description: Forbidden. This can happen when the OAuth token scope is `sessions:app`, but the `channel_data` property in the request is browser related.
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorResponse'
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorResponse'
-    '501':
-      description: Not Implemented
-    '503':
-      description: Service not available. A temporary server error.
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorResponse'
+            $ref: '#/components/schemas/SessionRequest'
+    responses:
+      '201':
+        description: Session processed successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSessionOkResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '202':
+        description: Session accepted and further action required
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSessionAcceptedResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '403':
+        description: Forbidden. This can happen when the OAuth token scope is `sessions:app`, but the `channel_data` property in the request is browser related.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorResponse'
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorResponse'
+      '501':
+        description: Not Implemented
+      '503':
+        description: Service not available. A temporary server error.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorResponse'

--- a/nas_spec/paths/sessions@{id}.yaml
+++ b/nas_spec/paths/sessions@{id}.yaml
@@ -1,56 +1,57 @@
-get:
-  tags:
-    - Sessions
-  security:
-    - OAuth:
-        - sessions:app
-        - sessions:browser
-    - SessionSecret: []
-  summary: Get session details
-  description: |
-    Returns the details of the session with the specified identifier string.
-  parameters:
-    - name: id
-      in: path
-      description: Session ID
-      required: true
-      schema:
-        type: string
-    - name: channel
-      in: header
-      description: Optionally provide the type of channnel so you only get the relevant actions
-      schema:
-        type: string
-        enum:
-          - browser
-          - app
-        description: If a value is not provided, and if the `status` is `pending`, then `next_actions` will return `collect_channel_data` and if available, `issuer_fingerprint`.
-        example: browser
-  responses:
-    '200':
-      description: Session retrieved successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/GetSessionResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '403':
-      description: Forbidden. This can happen when the OAuth token scope is `sessions:app`, but the session was initiated with the scope `sessions:browser`.
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorResponse'
-    '404':
-      description: Session not found
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorResponse'
-    '502':
-      description: Bad gateway
+/sessions/{id}:
+  get:
+    tags:
+      - Sessions
+    security:
+      - OAuth:
+          - sessions:app
+          - sessions:browser
+      - SessionSecret: []
+    summary: Get session details
+    description: |
+      Returns the details of the session with the specified identifier string.
+    parameters:
+      - name: id
+        in: path
+        description: Session ID
+        required: true
+        schema:
+          type: string
+      - name: channel
+        in: header
+        description: Optionally provide the type of channnel so you only get the relevant actions
+        schema:
+          type: string
+          enum:
+            - browser
+            - app
+          description: If a value is not provided, and if the `status` is `pending`, then `next_actions` will return `collect_channel_data` and if available, `issuer_fingerprint`.
+          example: browser
+    responses:
+      '200':
+        description: Session retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetSessionResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '403':
+        description: Forbidden. This can happen when the OAuth token scope is `sessions:app`, but the session was initiated with the scope `sessions:browser`.
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorResponse'
+      '404':
+        description: Session not found
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorResponse'
+      '502':
+        description: Bad gateway

--- a/nas_spec/paths/sessions@{id}@collect-data.yaml
+++ b/nas_spec/paths/sessions@{id}@collect-data.yaml
@@ -1,50 +1,51 @@
-put:
-  security:
-    - OAuth:
-        - sessions:app
-        - sessions:browser
-    - SessionSecret: []
-  summary: Update a session
-  description: Update a session by providing information about the environment.
-  tags:
-    - Sessions
-  parameters:
-    - name: id
-      in: path
-      description: Session ID
-      required: true
-      schema:
-        type: string
-  requestBody:
-    required: true
-    content:
-      application/json:
+/sessions/{id}/collect-data:
+  put:
+    security:
+      - OAuth:
+          - sessions:app
+          - sessions:browser
+      - SessionSecret: []
+    summary: Update a session
+    description: Update a session by providing information about the environment.
+    tags:
+      - Sessions
+    parameters:
+      - name: id
+        in: path
+        description: Session ID
+        required: true
         schema:
-          $ref: '#/components/schemas/ChannelData'
-  responses:
-    '200':
-      description: Session updated successfully
+          type: string
+    requestBody:
+      required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/GetSessionResponse'
-    '401':
-      description: Unauthorized
-    '403':
-      description: Forbidden
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorResponse'
-    '404':
-      description: Session not found
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorResponse'
-    '422':
-      description: Unprocessable channel information
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorResponse'
+            $ref: '#/components/schemas/ChannelData'
+    responses:
+      '200':
+        description: Session updated successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetSessionResponse'
+      '401':
+        description: Unauthorized
+      '403':
+        description: Forbidden
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorResponse'
+      '404':
+        description: Session not found
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorResponse'
+      '422':
+        description: Unprocessable channel information
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorResponse'

--- a/nas_spec/paths/sessions@{id}@complete.yaml
+++ b/nas_spec/paths/sessions@{id}@complete.yaml
@@ -1,57 +1,58 @@
-post:
-  security:
-    - OAuth:
-        - sessions:app
-        - sessions:browser
-    - SessionSecret: []
-  summary: Complete a session
-  description: |
-    Completes a session by posting the the following request to the callback URL (only relevant for non hosted sessions):
-    ```
-    {
-       "session_id": "sid_llraltf4jlwu5dxdtprcv7ba5i",
-       "amount" : 6540,
-       "currency": "USD",
-       "status": "approved",
-       "authentication_type": "regular",
-       "authentication_category": "payment",
-       "reference": "ORD-5023-4E89",
-       "approved": true,
-       "protocol_version": "2.1.0",
-       "response_code": "Y",
-       "response_reason": "01",
-       "cryptogram": "MTIzNDU2Nzg5MDA5ODc2NTQzMjE=",
-       "eci": "05",
-       "xid": "XSUErNftqkiTdlkpSk8p32GWOFA",
-       "cardholder_info": "Card declined. Please contact your issuing bank.",
-       "challenged": true
-    }
-    ```
-    <br/>
-    The fields of the above are the same as they would be in a GET session response
-  tags:
-    - Sessions
-  parameters:
-    - name: id
-      in: path
-      description: Session ID
-      required: true
-      schema:
-        type: string
-  responses:
-    '204':
-      description: Session completed successfully
-    '401':
-      description: Unauthorized
-    '403':
-      description: Forbidden
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorResponse'
-    '404':
-      description: Session not found
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorResponse'
+/sessions/{id}/complete:
+  post:
+    security:
+      - OAuth:
+          - sessions:app
+          - sessions:browser
+      - SessionSecret: []
+    summary: Complete a session
+    description: |
+      Completes a session by posting the the following request to the callback URL (only relevant for non hosted sessions):
+      ```
+      {
+         "session_id": "sid_llraltf4jlwu5dxdtprcv7ba5i",
+         "amount" : 6540,
+         "currency": "USD",
+         "status": "approved",
+         "authentication_type": "regular",
+         "authentication_category": "payment",
+         "reference": "ORD-5023-4E89",
+         "approved": true,
+         "protocol_version": "2.1.0",
+         "response_code": "Y",
+         "response_reason": "01",
+         "cryptogram": "MTIzNDU2Nzg5MDA5ODc2NTQzMjE=",
+         "eci": "05",
+         "xid": "XSUErNftqkiTdlkpSk8p32GWOFA",
+         "cardholder_info": "Card declined. Please contact your issuing bank.",
+         "challenged": true
+      }
+      ```
+      <br/>
+      The fields of the above are the same as they would be in a GET session response
+    tags:
+      - Sessions
+    parameters:
+      - name: id
+        in: path
+        description: Session ID
+        required: true
+        schema:
+          type: string
+    responses:
+      '204':
+        description: Session completed successfully
+      '401':
+        description: Unauthorized
+      '403':
+        description: Forbidden
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorResponse'
+      '404':
+        description: Session not found
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorResponse'

--- a/nas_spec/paths/sessions@{id}@issuer-fingerprint.yaml
+++ b/nas_spec/paths/sessions@{id}@issuer-fingerprint.yaml
@@ -1,49 +1,50 @@
-put:
-  security:
-    - OAuth:
-        - sessions:browser
-    - SessionSecret: []
-  summary: Update session 3DS Method completion indicator
-  description: Update the session's 3DS Method completion indicator based on the result of accessing the 3DS Method URL.
-  tags:
-    - Sessions
-  parameters:
-    - name: id
-      in: path
-      description: Session ID
-      required: true
-      schema:
-        type: string
-  requestBody:
-    required: true
-    content:
-      application/json:
+/sessions/{id}/issuer-fingerprint:
+  put:
+    security:
+      - OAuth:
+          - sessions:browser
+      - SessionSecret: []
+    summary: Update session 3DS Method completion indicator
+    description: Update the session's 3DS Method completion indicator based on the result of accessing the 3DS Method URL.
+    tags:
+      - Sessions
+    parameters:
+      - name: id
+        in: path
+        description: Session ID
+        required: true
         schema:
-          $ref: '#/components/schemas/ThreeDsMethodCompletion'
-  responses:
-    '200':
-      description: Session updated successfully
+          type: string
+    requestBody:
+      required: true
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/GetSessionResponseAfterChannelDataSupplied'
-    '401':
-      description: Unauthorized
-    '403':
-      description: Forbidden
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorResponse'
-    '404':
-      description: Session not found
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorResponse'
-    '422':
-      description: Unprocessable channel information
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ErrorResponse'
+            $ref: '#/components/schemas/ThreeDsMethodCompletion'
+    responses:
+      '200':
+        description: Session updated successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GetSessionResponseAfterChannelDataSupplied'
+      '401':
+        description: Unauthorized
+      '403':
+        description: Forbidden
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorResponse'
+      '404':
+        description: Session not found
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorResponse'
+      '422':
+        description: Unprocessable channel information
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ErrorResponse'

--- a/nas_spec/paths/tokens.yaml
+++ b/nas_spec/paths/tokens.yaml
@@ -1,36 +1,37 @@
-post:
-  tags:
-    - Tokens
-  security:
-    - ApiPublicKey: []
-  summary: Request a token
-  description: |
-    Exchange card details for a reference token that can be used later to request a card payment. Tokens are single use and expire after 15 minutes. 
-    To create a token, please authenticate using your public key. 
+/tokens:
+  post:
+    tags:
+      - Tokens
+    security:
+      - ApiPublicKey: []
+    summary: Request a token
+    description: |
+      Exchange card details for a reference token that can be used later to request a card payment. Tokens are single use and expire after 15 minutes.
+      To create a token, please authenticate using your public key.
 
-    **Please note:** You should only use the `card` type for testing purposes.
-  requestBody:
-    content:
-      application/json:
-        schema:
-          $ref: '#/components/schemas/TokenRequest'
-  responses:
-    '201':
-      description: Reference token created successfully
+      **Please note:** You should only use the `card` type for testing purposes.
+    requestBody:
       content:
         application/json:
           schema:
-            $ref: '#/components/schemas/TokenResponse'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
+            $ref: '#/components/schemas/TokenRequest'
+    responses:
+      '201':
+        description: Reference token created successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/TokenResponse'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'

--- a/nas_spec/paths/validation@bank-accounts@{country}@{currency}.yaml
+++ b/nas_spec/paths/validation@bank-accounts@{country}@{currency}.yaml
@@ -1,73 +1,74 @@
-get:
-  tags:
-    - Instruments
-  security:
-    - OAuth:
-        - payouts:bank-details
-  summary: Get bank account field formatting
-  description: |
-    Returns the bank account field formatting required to create bank account instruments or perform payouts for the specified country and currency.
-  parameters:
-    - in: path
-      name: country
-      schema:
-        type: string
-        minLength: 2
-        maxLength: 2
-      required: true
-      description: |
-        The two-letter <a href="https://docs.checkout.com/four/resources/codes/country-codes" target="_blank">ISO country code</a>
-    - in: path
-      name: currency
-      schema:
-        type: string
-        minLength: 3
-        maxLength: 3
-      required: true
-      description: |
-        The three-letter <a href="https://docs.checkout.com/four/resources/codes/currency-codes" target="_blank">ISO currency code</a>
-    - in: query
-      name: account-holder-type
-      schema:
-        type: string
-        enum:
-          - individual
-          - corporate
-          - government
-      description: |
-        The type of account holder that will be used to filter the fields returned
-    - in: query
-      name: payment-network
-      schema:
-        type: string
-        enum:
-          - local
-          - sepa
-          - fps
-          - ach
-          - fedwire
-          - swift
-      description: |
-        The banking network that will be used to filter the fields returned
-  responses:
-    '200':
-      description: Bank account fields retrieved successfully
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/BankAccountFields'
-      headers:
-        Cko-Request-Id:
-          $ref: '#/components/headers/Cko-Request-Id'
-        Cko-Version:
-          $ref: '#/components/headers/Cko-Version'
-    '401':
-      description: Unauthorized
-    '404':
-      description: Fields not found
-    '422':
-      description: Invalid data was sent
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/ValidationError'
+/validation/bank-accounts/{country}/{currency}:
+  get:
+    tags:
+      - Instruments
+    security:
+      - OAuth:
+          - payouts:bank-details
+    summary: Get bank account field formatting
+    description: |
+      Returns the bank account field formatting required to create bank account instruments or perform payouts for the specified country and currency.
+    parameters:
+      - in: path
+        name: country
+        schema:
+          type: string
+          minLength: 2
+          maxLength: 2
+        required: true
+        description: |
+          The two-letter <a href="https://docs.checkout.com/four/resources/codes/country-codes" target="_blank">ISO country code</a>
+      - in: path
+        name: currency
+        schema:
+          type: string
+          minLength: 3
+          maxLength: 3
+        required: true
+        description: |
+          The three-letter <a href="https://docs.checkout.com/four/resources/codes/currency-codes" target="_blank">ISO currency code</a>
+      - in: query
+        name: account-holder-type
+        schema:
+          type: string
+          enum:
+            - individual
+            - corporate
+            - government
+        description: |
+          The type of account holder that will be used to filter the fields returned
+      - in: query
+        name: payment-network
+        schema:
+          type: string
+          enum:
+            - local
+            - sepa
+            - fps
+            - ach
+            - fedwire
+            - swift
+        description: |
+          The banking network that will be used to filter the fields returned
+    responses:
+      '200':
+        description: Bank account fields retrieved successfully
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/BankAccountFields'
+        headers:
+          Cko-Request-Id:
+            $ref: '#/components/headers/Cko-Request-Id'
+          Cko-Version:
+            $ref: '#/components/headers/Cko-Version'
+      '401':
+        description: Unauthorized
+      '404':
+        description: Fields not found
+      '422':
+        description: Invalid data was sent
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ValidationError'

--- a/src/OpenApiGenerator/Program.cs
+++ b/src/OpenApiGenerator/Program.cs
@@ -144,7 +144,6 @@ namespace OpenApiGenerator
                 {
                     path = fileInfo.Name.Substring(0, fileInfo.Name.IndexOf(".")).Replace("@", "/");
                     path = new Regex(@"^_.+").Replace(path, "");
-                    text += ($"  /{path}:\n");
 
                     var s = "";
                     var currentVerb = "";


### PR DESCRIPTION
I'm proposing what I *hope* is a useful reorganisation of the `/paths` data in our OpenAPI spec. It's outside the scope of just tech writers so do please tell me who needs to review. If we decide not to do this that's totally fine, but I'd like to discuss it :D 

Pros:
* We get more control over the order in which endpoints appear in the reference and in the Postman collection we'll be using this spec to autogenerate—currently it's all automatically alphabetical and I'm not aware of a way within OpenAPI to enforce manual organisation
* Slightly easier file organisation 

Cons I am aware of:
* People might be used to the current system, so some minor mistakes may arise