### PR TITLE
Adds custom x-cko-type field 

### DIFF
--- a/abc_spec/components/securitySchemes/ApiPublicKey.yaml
+++ b/abc_spec/components/securitySchemes/ApiPublicKey.yaml
@@ -14,3 +14,4 @@ description: >
 name: Authorization
 type: apiKey
 in: header
+x-cko-type: publicKey

--- a/abc_spec/components/securitySchemes/ApiSecretKey.yaml
+++ b/abc_spec/components/securitySchemes/ApiSecretKey.yaml
@@ -12,3 +12,4 @@ description: >
 name: Authorization
 type: apiKey
 in: header
+x-cko-type: secretKey

--- a/nas_spec/components/securitySchemes/ApiPublicKey.yaml
+++ b/nas_spec/components/securitySchemes/ApiPublicKey.yaml
@@ -11,3 +11,4 @@ description: |
 name: Authorization
 type: apiKey
 in: header
+x-cko-type: publicKey

--- a/nas_spec/components/securitySchemes/ApiSecretKey.yaml
+++ b/nas_spec/components/securitySchemes/ApiSecretKey.yaml
@@ -25,3 +25,4 @@ description: |
 name: Authorization
 type: apiKey
 in: header
+x-cko-type: secretKey


### PR DESCRIPTION
This is to work with my fork of openapi2postman (ckoopenapi2postman 😅 ): 

https://github.com/ben-ahmady-cko/openapi-to-postman/commit/15a9baa93f6efa7d746ba4c4162e124a12ad2be9

It's so we can get `{{secretKey}}` or `{{publicKey}}` plugged straight into the `Authorization` header in Postman collections generated using this spec, depending on what value `x-cko-type` takes (`secretKey` and `publicKey` are recognised by the fork: I should add an `else` condition to the fork itself as well but that's a separate project and still very much WIP). 

`x-cko-type` itself should have no bearing on Redoc or Redocly since for every intent/purpose except this one it's useless and follows the correct standard for custom OpenAPI fields AFAIK