### PR TITLE
Add download button for spec

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -28,7 +28,7 @@
 		</div>
 		<script src="js/theme.js"></script>
 
-		<redoc spec-url="./swagger.yaml" hide-loading hide-download-button></redoc>
+		<redoc spec-url="./swagger.yaml"></redoc>
 
 		<script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.40/bundles/redoc.standalone.js"></script>
 	</body>

--- a/web/preview/crusoe/index.html
+++ b/web/preview/crusoe/index.html
@@ -28,7 +28,7 @@
 		</div>
 		<script src="../../js/theme.js"></script>
 
-		<redoc spec-url="./swagger.yaml" hide-loading hide-download-button></redoc>
+		<redoc spec-url="./swagger.yaml"></redoc>
 
 		<script src="https://cdn.jsdelivr.net/npm/redoc@2.0.0-rc.40/bundles/redoc.standalone.js"></script>
 	</body>


### PR DESCRIPTION
Charlie has had feedback from a lot of merchants that said the download button for the whole spec was requested. Because of the work Jack did in splitting the abc and nas spec folders (instead of nas just being on a preview branch), we can now show the download button. One is for nas and one for abc.