### PR TITLE
DOC-635: Aadd transaction_risk_assessment to 3ds.exemption

### DIFF
--- a/abc_spec/components/schemas/Payments/3dsRequest.yaml
+++ b/abc_spec/components/schemas/Payments/3dsRequest.yaml
@@ -40,4 +40,5 @@ properties:
       - low_value
       - secure_corporate_payment
       - trusted_listing
+      - transaction_risk_assessment
     example: 'low_value'

--- a/nas_spec/components/schemas/Payments/3dsData.yaml
+++ b/nas_spec/components/schemas/Payments/3dsData.yaml
@@ -43,5 +43,6 @@ properties:
       - low_value
       - secure_corporate_payment
       - trusted_listing
+      - transaction_risk_assessment
     description: Specifies an exemption reason so that the payment is not processed using 3D Secure authentication. Learn more about exemptions in our <a href="https://docs.checkout.com/four/payments/regulation-support/sca-compliance-guide#SCAcomplianceguide-PossibleSCAexemptionsexemptions" target="_blank">SCA compliance guide</a>
     example: 'low_value'

--- a/nas_spec/components/schemas/Payments/3dsRequest.yaml
+++ b/nas_spec/components/schemas/Payments/3dsRequest.yaml
@@ -39,5 +39,6 @@ properties:
       - low_value
       - secure_corporate_payment
       - trusted_listing
+      - transaction_risk_assessment
     description: Specifies an exemption reason so that the payment is not processed using 3D Secure authentication. Learn more about exemptions in our <a href="https://docs.checkout.com/four/payments/regulation-support/sca-compliance-guide#SCAcomplianceguide-PossibleSCAexemptionsexemptions" target="_blank">SCA compliance guide</a>
     example: 'low_value'


### PR DESCRIPTION
https://checkout.atlassian.net/browse/DOC-635
`transaction_risk_assessment` is one of the acceptable exemptions that can be sent with a payment request.

[here](https://checkout.atlassian.net/browse/GW-3665) is the initial work
