### PR TITLE
Adds missing fields on Payment Links

### DIFF
--- a/abc_spec/components/schemas/PaymentLinks/GetPaymentLinkResponse.yaml
+++ b/abc_spec/components/schemas/PaymentLinks/GetPaymentLinkResponse.yaml
@@ -72,6 +72,19 @@ properties:
         type: string
         description: The customer's name.
         example: Bruce Wayne
+  shipping:
+    type: object
+    description: The address any products are being sent to.
+    required:
+      - address
+    properties:
+      address:
+        type: object
+        description: The customer's address to ship to.
+        required:
+          - country
+        allOf:
+          - $ref: '#/components/schemas/Address'
   billing:
     type: object
     additionalProperties: false
@@ -124,5 +137,27 @@ properties:
   return_url:
     type: string
     format: uri
-    description: The provided success page where your customer will be redirected to.
+    description: If provided, the success page will include a button that redirects your customer to the provided URL.
     example: https://example.com/success
+    maxLength: 255
+  locale:
+    type: string
+    description: Creates a translated version of the page in the specified language
+    enum:
+      - de-DE
+      - en-GB
+      - fr-FR
+      - it-IT
+      - nl-NL
+      - es-ES
+      - zh-HK
+      - zh-TW
+      - zh-CN
+      - ja-JP
+      - fil-PH
+      - id-ID
+      - ms-MY
+      - th-TH
+      - vi-VN
+      - hi-IN
+    default: en-GB

--- a/nas_spec/components/schemas/PaymentLinks/GetPaymentLinkResponse.yaml
+++ b/nas_spec/components/schemas/PaymentLinks/GetPaymentLinkResponse.yaml
@@ -59,6 +59,13 @@ properties:
     description: The date and time when the Payment Link expires.
     format: date-time
     example: '2021-08-20T20:25:28+08:00'
+  processing_channel_id:
+    type: string
+    pattern: "^(pc)_(\\w{26})$"
+    description: The processing channel to be used for the payment
+    example: 'pc_q4dbxom5jbgudnjzjpz7j2z6uq'
+  marketplace:
+    $ref: '#/components/schemas/MarketplaceData'
   customer:
     type: object
     description: The customer's details.

--- a/nas_spec/components/schemas/PaymentLinks/GetPaymentLinkResponse.yaml
+++ b/nas_spec/components/schemas/PaymentLinks/GetPaymentLinkResponse.yaml
@@ -59,13 +59,6 @@ properties:
     description: The date and time when the Payment Link expires.
     format: date-time
     example: '2021-08-20T20:25:28+08:00'
-  processing_channel_id:
-    type: string
-    pattern: "^(pc)_(\\w{26})$"
-    description: The processing channel to be used for the payment
-    example: 'pc_q4dbxom5jbgudnjzjpz7j2z6uq'
-  marketplace:
-    $ref: '#/components/schemas/MarketplaceData'
   customer:
     type: object
     description: The customer's details.
@@ -79,6 +72,19 @@ properties:
         type: string
         description: The customer's name.
         example: Bruce Wayne
+  shipping:
+    type: object
+    description: The address any products are being sent to.
+    required:
+      - address
+    properties:
+      address:
+        type: object
+        description: The customer's address to ship to.
+        required:
+          - country
+        allOf:
+          - $ref: '#/components/schemas/Address'
   billing:
     type: object
     additionalProperties: false
@@ -131,5 +137,27 @@ properties:
   return_url:
     type: string
     format: uri
-    description: The provided success page where your customer will be redirected to.
+    description: If provided, the success page will include a button that redirects your customer to the provided URL.
     example: https://example.com/success
+    maxLength: 255
+  locale:
+    type: string
+    description: Creates a translated version of the page in the specified language
+    enum:
+      - de-DE
+      - en-GB
+      - fr-FR
+      - it-IT
+      - nl-NL
+      - es-ES
+      - zh-HK
+      - zh-TW
+      - zh-CN
+      - ja-JP
+      - fil-PH
+      - id-ID
+      - ms-MY
+      - th-TH
+      - vi-VN
+      - hi-IN
+    default: en-GB


### PR DESCRIPTION
The API reference for the GET /payment-links route is missing the following properties/definitions and examples.

Shipping object

return_url

locale