### PR TITLE
Pi 859 remove limit of products.price

### DIFF
--- a/abc_spec/components/schemas/HostedPayments/HostedPaymentsRequest.yaml
+++ b/abc_spec/components/schemas/HostedPayments/HostedPaymentsRequest.yaml
@@ -118,7 +118,6 @@ properties:
           type: integer
           description: 'Minor units. Includes tax, excludes discounts. The exact format <a href="https://docs.checkout.com/docs/calculating-the-value" target="_blank">depends on the currency</a>'
           minimum: 0
-          maximum: 100000000
           example: 1000
   risk:
     $ref: '#/components/schemas/RiskRequest'

--- a/abc_spec/components/schemas/PaymentLinks/PaymentLinksRequest.yaml
+++ b/abc_spec/components/schemas/PaymentLinks/PaymentLinksRequest.yaml
@@ -123,7 +123,6 @@ properties:
           type: integer
           description: Minor units. Includes tax, excludes discounts.
           minimum: 0
-          maximum: 100000000
           example: 200
   metadata:
     type: object

--- a/abc_spec/swagger.yaml
+++ b/abc_spec/swagger.yaml
@@ -51,6 +51,7 @@ info:
 
      | Date          |      Description of change                                        |
      |---------------|-------------------------------------------------------------------|
+     | 2021/12/14    |  Removed upper limit for `products.price`                         |
      | 2021/11/11    |  Added `3ds.challenge_indicator` to card payment requests.        |
      | 2021/10/18    |  Added `processing.purpose` to card payouts.                      |
      | 2021/10/18    |  Added `recommendation_code` to payment response.                 |

--- a/nas_spec/components/schemas/HostedPayments/HostedPaymentsRequest.yaml
+++ b/nas_spec/components/schemas/HostedPayments/HostedPaymentsRequest.yaml
@@ -118,7 +118,6 @@ properties:
           type: integer
           description: 'Minor units. Includes tax, excludes discounts. The exact format <a href="https://docs.checkout.com/docs/calculating-the-value" target="_blank">depends on the currency</a>'
           minimum: 0
-          maximum: 100000000
           example: 1000
   risk:
     $ref: '#/components/schemas/RiskRequest'

--- a/nas_spec/components/schemas/PaymentLinks/PaymentLinksRequest.yaml
+++ b/nas_spec/components/schemas/PaymentLinks/PaymentLinksRequest.yaml
@@ -123,7 +123,6 @@ properties:
           type: integer
           description: Minor units. Includes tax, excludes discounts.
           minimum: 0
-          maximum: 100000000
           example: 200
   metadata:
     type: object

--- a/nas_spec/swagger.yaml
+++ b/nas_spec/swagger.yaml
@@ -48,6 +48,7 @@ info:
 
      | Date          |      Description of change                                        |
      |---------------|-------------------------------------------------------------------|
+     | 2021/12/14    |  Removed upper limit for `products.price`                         |
      | 2021/11/11    |  Added `3ds.challenge_indicator` to card payment requests.        |
      | 2021/11/03    |  Adds `identification` object under parent `sender` object in payment request. |
      | 2021/10/18    |  Added the `marketplaces.sub-entities` object to support split payments.  |


### PR DESCRIPTION
# Description of changes in PR

[//]: # 'Removed upper limit for products.price'

## Checklist

- [X] Added a changelog entry on the `swagger.yaml` file
- [X] Contacted the Tech Docs team about any corresponding guides that need to be updated for www.checkout.com/docs

**Contributing options**: Look at [our documentation](https://checkout.atlassian.net/wiki/spaces/PD/pages/2169506663/API+ref+publication+process) for options to contribute to the API reference.
