### PR TITLE
Add Header parameters for capture, refund, void

### DIFF
--- a/nas_spec/paths/payments@{id}@captures.yaml
+++ b/nas_spec/paths/payments@{id}@captures.yaml
@@ -12,6 +12,7 @@ post:
 
     For card payments, capture requests are processed asynchronously. You can use [workflows](#tag/Workflows) to be notified if the capture is successful.
   parameters:
+    - $ref: '#/components/parameters/ckoIdempotencyKey'
     - in: path
       name: id
       schema:
@@ -19,8 +20,6 @@ post:
         pattern: "^(pay)_(\\w{26})$"
       required: true
       description: The payment identifier
-  parameters:
-    - $ref: '#/components/parameters/ckoIdempotencyKey'
   requestBody:
     content:
       application/json:

--- a/nas_spec/paths/payments@{id}@captures.yaml
+++ b/nas_spec/paths/payments@{id}@captures.yaml
@@ -19,6 +19,8 @@ post:
         pattern: "^(pay)_(\\w{26})$"
       required: true
       description: The payment identifier
+  parameters:
+    - $ref: '#/components/parameters/ckoIdempotencyKey'
   requestBody:
     content:
       application/json:

--- a/nas_spec/paths/payments@{id}@refunds.yaml
+++ b/nas_spec/paths/payments@{id}@refunds.yaml
@@ -12,6 +12,7 @@ post:
 
     For card payments, refund requests are processed asynchronously. You can use [workflows](#tag/Workflows) to be notified if the refund is successful.
   parameters:
+    - $ref: '#/components/parameters/ckoIdempotencyKey'
     - in: path
       name: id
       schema:
@@ -19,8 +20,6 @@ post:
         pattern: "^(pay)_(\\w{26})$"
       required: true
       description: The payment identifier
-  parameters:
-    - $ref: '#/components/parameters/ckoIdempotencyKey'
   requestBody:
     content:
       application/json:

--- a/nas_spec/paths/payments@{id}@refunds.yaml
+++ b/nas_spec/paths/payments@{id}@refunds.yaml
@@ -19,6 +19,8 @@ post:
         pattern: "^(pay)_(\\w{26})$"
       required: true
       description: The payment identifier
+  parameters:
+    - $ref: '#/components/parameters/ckoIdempotencyKey'
   requestBody:
     content:
       application/json:

--- a/nas_spec/paths/payments@{id}@voids.yaml
+++ b/nas_spec/paths/payments@{id}@voids.yaml
@@ -12,6 +12,7 @@ post:
 
     For card payments, void requests are processed asynchronously. You can use [workflows](#tag/Workflows) to be notified if the void is successful.
   parameters:
+    - $ref: '#/components/parameters/ckoIdempotencyKey'
     - in: path
       name: id
       schema:
@@ -19,8 +20,6 @@ post:
         pattern: "^(pay)_(\\w{26})$"
       required: true
       description: The payment identifier
-  parameters:
-    - $ref: '#/components/parameters/ckoIdempotencyKey'
   requestBody:
     content:
       application/json:

--- a/nas_spec/paths/payments@{id}@voids.yaml
+++ b/nas_spec/paths/payments@{id}@voids.yaml
@@ -19,6 +19,8 @@ post:
         pattern: "^(pay)_(\\w{26})$"
       required: true
       description: The payment identifier
+  parameters:
+    - $ref: '#/components/parameters/ckoIdempotencyKey'
   requestBody:
     content:
       application/json:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "gateway-openapi-spec",
+  "name": "checkout-openapi-spec",
   "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,


### PR DESCRIPTION
# Description of changes in PR

Added Header parameter Cko-Idempotency-Key to Capture, Refunds and Void on NAS.

## Checklist

- Added Header parameter Cko-Idempotency-Key on the `payments@{id}@captures.yaml`, `payments@{id}@refunds.yaml` and `payments@{id}@voids.yaml` files.
