### PR TITLE
Add missing fields to GET response on ABC

### DIFF
--- a/abc_spec/components/schemas/Payments/Payment.yaml
+++ b/abc_spec/components/schemas/Payments/Payment.yaml
@@ -10,7 +10,7 @@ required:
   - _links
 properties:
   id:
-    description: Payment unique identifier
+    description: Payment unique identifier  
     allOf:
       - $ref: '#/components/schemas/PaymentId'
   requested_on:

--- a/abc_spec/components/schemas/Payments/PaymentResponseSource.yaml
+++ b/abc_spec/components/schemas/Payments/PaymentResponseSource.yaml
@@ -36,7 +36,7 @@ properties:
       this will be `card`; otherwise it will be the name of the alternative payment method<br> BenefitPay is **DEPRECATED**
     example: 'card'
   id:
-    type: string
+    type: string 
     description: |
       The payment source identifier that can be used for subsequent payments.
       For new sources, this will only be returned if the payment was approved
@@ -48,4 +48,71 @@ properties:
   phone:
     description: The payment source owner's phone number
     allOf:
-      - $ref: '#/components/schemas/PhoneNumber'
+      - $ref: '#/components/schemas/PhoneNumber' 
+  expiry_month:
+    type: integer 
+    description: The expiry month
+    minLength: 1
+    maxLength: 2
+    example: '6'
+  expiry_year:
+    type: integer
+    description: The expiry year
+    maxLength: 4
+    example: '2025'
+  name:
+    type: string
+    description: The cardholder's name
+    example: 'Bruce Wayne'
+  scheme:
+    type: string
+    description: The card scheme
+    example: 'Visa'
+  last4:
+    type: string
+    description: The last four digits of the card number
+    example: '9996'
+  fingerprint:
+    type: string
+    description: Uniquely identifies this particular card number. You can use this to compare cards across customers.
+    example: '31CFD9C909A2A99EB03E50675A60E67E7F5633B4A277C2D63B4BCF1302A2D934'
+  bin:
+    type: string
+    description: The card issuer's Bank Identification Number (BIN)
+    maxLength: 6
+    example: '454347'
+  card_type:
+    type: string
+    description: The card type
+    enum:
+      - Credit
+      - Debit
+      - Prepaid
+      - Charge
+      - Deferred Debit
+    example: 'Credit'
+  card_category:
+    type: string
+    description: The card category
+    enum:
+      - Consumer
+      - Commercial
+    example: 'Consumer'
+  issuer:
+    type: string
+    description: The name of the card issuer
+    example: 'STATE BANK OF MAURITIUS, LTD.'
+  issuer_country:
+    type: string
+    description: The card issuer's country (**two-letter ISO code**)
+    minLength: 2
+    maxLength: 2
+    example: 'MU'
+  product_id:
+    type: string
+    description: The issuer/card scheme product identifier
+    example: 'F'
+  product_type:
+    type: string
+    description: The issuer/card scheme product type
+    example: 'Visa Classic'


### PR DESCRIPTION
# Description of changes in PR

Added missing fields to the `source` object in the GET payment details 200 response sample on the ABC API Ref.

## Checklist

- [ ] Added the following fields on the `PaymentResponseSource.yaml` file:
      "expiry_month":6,
      "expiry_year":2025,
      "name":"Bruce Wayne",
      "scheme":"Visa",
      "last4":"9996",
      "fingerprint":"31CFD9C909A2A99EB03E50675A60E67E7F5633B4A277C2D63B4BCF1302A2D934",
      "bin":"454347",
      "card_type":"Credit",
      "card_category":"Consumer",
      "issuer":"STATE BANK OF MAURITIUS, LTD.",
      "issuer_country":"MU",
      "product_id":"F",
      "product_type":"Visa Classic"
