### PR TITLE
Add idempotency-key to Increment authorization

### DIFF
--- a/nas_spec/paths/payments@{id}@authorizations.yaml
+++ b/nas_spec/paths/payments@{id}@authorizations.yaml
@@ -11,6 +11,7 @@ post:
     Request an incremental authorization to increase the authorization amount or extend the authorization's validity period.
 
   parameters:
+    - $ref: '#/components/parameters/ckoIdempotencyKey'
     - in: path
       name: id
       schema:


### PR DESCRIPTION
# Description of changes in PR

Added the optional `Cko-Idempotency-Key` header parameter to the Increment authorization endpoint on NAS API ref.

## Checklist

- [ ] Added the optional `Cko-Idempotency-Key` header parameter on the `payments@{id}@authorizations.yaml` file.
