### PR TITLE
[DONOTMERGE] Add preferred_scheme to upapi and details response

### DIFF
--- a/nas_spec/components/schemas/Payments/PaymentDetails.yaml
+++ b/nas_spec/components/schemas/Payments/PaymentDetails.yaml
@@ -144,6 +144,8 @@ properties:
     $ref: '#/components/schemas/MarketplaceData'
   recipient:
     $ref: '#/components/schemas/PaymentRecipient'
+  processing:
+    $ref: '#/components/schemas/ProcessingData'
   metadata:
     type: object
     description: A set of key-value pairs that you can attach to a payment. It can be useful for storing additional information in a structured format

--- a/nas_spec/components/schemas/Payments/ProcessingData.yaml
+++ b/nas_spec/components/schemas/Payments/ProcessingData.yaml
@@ -1,0 +1,11 @@
+﻿type: object
+description: Information related to marketplace payments
+properties:
+  preferred_scheme:
+    type: Enum
+    enum:
+      - "mastercard"
+      - "visa"
+      - "cartes_bancaires"
+    description: Specifies the preferred scheme for a CoBrand payment.
+    example: 'cartes_bancaires'

--- a/nas_spec/components/schemas/Payments/ProcessingData.yaml
+++ b/nas_spec/components/schemas/Payments/ProcessingData.yaml
@@ -7,5 +7,5 @@ properties:
       - "mastercard"
       - "visa"
       - "cartes_bancaires"
-    description: Specifies the preferred scheme for a CoBrand payment.
+    description: The cardholder chosen scheme for cobranded cards. If the authentication is processed prior to the payment, specify the scheme that authenticated the transaction.
     example: 'cartes_bancaires'

--- a/nas_spec/components/schemas/Payments/ProcessingSettings.yaml
+++ b/nas_spec/components/schemas/Payments/ProcessingSettings.yaml
@@ -12,6 +12,13 @@ properties:
   aft:
     type: boolean
     description: Indicates whether the payment is an [Account Funding Transaction](https://docs.checkout.com/four/payments/manage-payments/account-funding-transactions)
+  preferred_scheme:
+    type: Enum
+    enum:
+      - "mastercard"
+      - "visa"
+      - "cartes_bancaires"
+    description: Specifies the preferred scheme for a CoBrand payment.
   # dlocal:
   #   type: object
   #   description: Processing information required for dLocal payments.

--- a/nas_spec/components/schemas/Payments/ProcessingSettings.yaml
+++ b/nas_spec/components/schemas/Payments/ProcessingSettings.yaml
@@ -18,7 +18,7 @@ properties:
       - "mastercard"
       - "visa"
       - "cartes_bancaires"
-    description: Specifies the preferred scheme for a CoBrand payment.
+    description: The cardholder chosen scheme for cobranded cards. If the authentication is processed prior to the payment, specify the scheme that authenticated the transaction.
   # dlocal:
   #   type: object
   #   description: Processing information required for dLocal payments.

--- a/nas_spec/swagger.yaml
+++ b/nas_spec/swagger.yaml
@@ -39,6 +39,7 @@ info:
 
       | Date       | Description of change                                                         |
       | ---------- | ----------------------------------------------------------------------------- |
+      | 2022/02/18 | Added the `preferred_scheme` to Processing to support CoBrand payments.       |
       | 2022/02/02 | Adds `active` property for workflows                                          |
       | 2022/01/26 | Update code samples for Java.                                                 |
       | 2022/01/25 | Update code samples for C#.                                                   |


### PR DESCRIPTION
# Description of changes in PR

- As a part of the Cartes Bancaires and CoBrand implementation, we will add a new preferred_scheme field in the processing object for the Payment Request
- The preferred_scheme field will also be returned in the processing object in the PaymentDetails 

## Checklist

- [x] Added a changelog entry on the `swagger.yaml` file
- [ ] Contacted the Tech Docs team about any corresponding guides that need to be updated for www.checkout.com/docs

**Contributing options**: Look at [our documentation](https://checkout.atlassian.net/wiki/spaces/PD/pages/2169506663/API+ref+publication+process) for options to contribute to the API reference.
