### PR TITLE
Trying to do a fix for different base urls

### DIFF
--- a/nas_spec/paths/balances@{id}.yaml
+++ b/nas_spec/paths/balances@{id}.yaml
@@ -2,6 +2,11 @@ parameters:
   - $ref: '#/components/parameters/EntityId'
   - $ref: '#/components/parameters/Query'
 get:
+  servers:
+    - url: https://balances.checkout.com
+      description: Production server
+    - url: https://balances.sandbox.checkout.com
+      description: Sandbox server
   summary: Retrieve entity balances
   description: Use this endpoint to retrieve balances for each currency account belonging to an entity.
   security:

--- a/nas_spec/paths/transfers.yaml
+++ b/nas_spec/paths/transfers.yaml
@@ -1,4 +1,9 @@
 post:
+  servers:
+    - url: https://transfers.checkout.com
+      description: Production server
+    - url: https://transfers.sandbox.checkout.com
+      description: Sandbox server
   security:
     - OAuth:
         - marketplace:transfer:create

--- a/src/OpenApiGenerator/Program.cs
+++ b/src/OpenApiGenerator/Program.cs
@@ -138,14 +138,17 @@ namespace OpenApiGenerator
       foreach (var file in yamlPathFiles)
       {
         var fileInfo = new FileInfo(file);
-        var path = "";
-
+        var path = ""; 
+       
         using (StreamReader sr = new StreamReader(file))
         {
           path = fileInfo.Name.Substring(0, fileInfo.Name.IndexOf(".")).Replace("@", "/");
           path = new Regex(@"^_.+").Replace(path, "");
+          path = new Regex(@"^balances.+").Replace(path, "{id}");
+          path = new Regex(@"^transfers+").Replace(path, "/");
+  
           text += ($"  /{path}:\n");
-
+    
           var s = "";
           var currentVerb = "";
           while ((s = sr.ReadLine()) != null)


### PR DESCRIPTION
Transfers and Balances have a different base URL - transfers.checkout.com and balances.checkout.com. We have to do a hack to get it to display without the path at the end of the base names. 

Balances is OK because it has an ID. However, we already did this hack with the marketplace files API. And when we remove the path from the transfers one, an error is thrown because of duplicate keys. So I've had to put an additional forward slash.

If this is the way forward for new APIs, we need to think of a different approach for writing the spec. 