### PR TITLE
AUTH: Remove network token restriction

### DIFF
--- a/nas_spec/components/schemas/Sessions/SessionSource.yaml
+++ b/nas_spec/components/schemas/Sessions/SessionSource.yaml
@@ -1,5 +1,5 @@
 ﻿type: object
-description: The source of the authentication. Using a `network_token` will return `501 Not Implemented`.
+description: The source of the authentication.
 discriminator:
   propertyName: type
   mapping:

--- a/nas_spec/paths/sessions.yaml
+++ b/nas_spec/paths/sessions.yaml
@@ -54,8 +54,6 @@ post:
         application/json:
           schema:
             $ref: '#/components/schemas/ErrorResponse'
-    '501':
-      description: Not Implemented
     '503':
       description: Service not available. A temporary server error.
       content:


### PR DESCRIPTION
https://checkout.atlassian.net/browse/AUTH-864

# Description of changes in PR

[//]: # Now that we support the source `network_token` in sessions, we can remove the text that says we do not support it

## Checklist

- [ ] Added a changelog entry on the `swagger.yaml` file
- [ ] Contacted the Tech Docs team about any corresponding guides that need to be updated for www.checkout.com/docs

**Contributing options**: Look at [our documentation](https://checkout.atlassian.net/wiki/spaces/PD/pages/2169506663/API+ref+publication+process) for options to contribute to the API reference.
