### PR TITLE
Update PHP code samples

### DIFF
--- a/abc_spec/changelog.md
+++ b/abc_spec/changelog.md
@@ -2,6 +2,7 @@
 
 | Date       | Description of change                                                                                           |
 | ---------- | --------------------------------------------------------------------------------------------------------------- |
+| 2022/03/28 | Update PHP code samples                                                                                         |
 | 2022/03/08 | Change C# samples to suggest the usage of `await` instead of `.Result`                                          |
 | 2022/02/23 | Added `allow_payment_methods` to Payment Links and Hosted Payments Page.                                        |
 | 2022/02/18 | Improved and added missing reporting code samples for Java & C#                                                 |

--- a/abc_spec/code_samples/PHP/customers/post.php
+++ b/abc_spec/code_samples/PHP/customers/post.php
@@ -1,0 +1,38 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Common\\Phone;
+use Checkout\\Customers\\CustomerRequest;
+use Checkout\\Environment;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$phone = new Phone();
+$phone->country_code = "1";
+$phone->number = "4155552671";
+
+$customerRequest = new CustomerRequest();
+$customerRequest->email = "email@docs.checkout.com";
+$customerRequest->name = "name";
+$customerRequest->phone = $phone;
+
+try {
+    $response = $api->getCustomersClient()->create($customerRequest);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/customers@{identifier}/delete.php
+++ b/abc_spec/code_samples/PHP/customers@{identifier}/delete.php
@@ -1,0 +1,27 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $api->getCustomersClient()->delete("customer_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/customers@{identifier}/get.php
+++ b/abc_spec/code_samples/PHP/customers@{identifier}/get.php
@@ -1,0 +1,27 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $response = $api->getCustomersClient()->get("customer_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/customers@{identifier}/patch.php
+++ b/abc_spec/code_samples/PHP/customers@{identifier}/patch.php
@@ -1,0 +1,38 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Common\\Phone;
+use Checkout\\Customers\\CustomerRequest;
+use Checkout\\Environment;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$phone = new Phone();
+$phone->country_code = "1";
+$phone->number = "4155552671";
+
+$customerRequest = new CustomerRequest();
+$customerRequest->email = "email@docs.checkout.com";
+$customerRequest->name = "name";
+$customerRequest->phone = $phone;
+
+try {
+    $api->getCustomersClient()->update("customer_id", $customerRequest);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/disputes/get.php
+++ b/abc_spec/code_samples/PHP/disputes/get.php
@@ -1,0 +1,43 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Disputes\\DisputesQueryFilter;
+use Checkout\\Environment;
+
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$query = new DisputesQueryFilter();
+$query->payment_id = "payment_id";
+$query->payment_arn = "payment_arn";
+$query->payment_reference = "payment_reference";
+$query->statuses = "comma,separated,list,statuses";
+$query->limit = 10;
+$query->skip = 5;
+$query->to = new DateTime(); // UTC, now
+
+$from = new DateTime();
+$from->setTimezone(new DateTimeZone("America/Mexico_City"));
+$from->sub(new DateInterval("P1Y"));
+$query->from = $from;
+
+try {
+    $response = $api->getDisputesClient()->query($query);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/disputes@{dispute_id}/get.php
+++ b/abc_spec/code_samples/PHP/disputes@{dispute_id}/get.php
@@ -1,0 +1,27 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $response = $api->getDisputesClient()->getDisputeDetails("dispute_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/disputes@{dispute_id}@accept/post.php
+++ b/abc_spec/code_samples/PHP/disputes@{dispute_id}@accept/post.php
@@ -1,0 +1,28 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $api->getDisputesClient()->accept("dispute_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}
+

--- a/abc_spec/code_samples/PHP/disputes@{dispute_id}@evidence/get.php
+++ b/abc_spec/code_samples/PHP/disputes@{dispute_id}@evidence/get.php
@@ -1,0 +1,27 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $response = $api->getDisputesClient()->getEvidence("dispute_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/disputes@{dispute_id}@evidence/post.php
+++ b/abc_spec/code_samples/PHP/disputes@{dispute_id}@evidence/post.php
@@ -1,0 +1,28 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $api->getDisputesClient()->submitEvidence("evidence_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}
+

--- a/abc_spec/code_samples/PHP/disputes@{dispute_id}@evidence/put.php
+++ b/abc_spec/code_samples/PHP/disputes@{dispute_id}@evidence/put.php
@@ -1,0 +1,38 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Disputes\\DisputeEvidenceRequest;
+use Checkout\\Environment;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$request = new DisputeEvidenceRequest();
+$request->proof_of_delivery_or_service_file = "file_id";
+$request->proof_of_delivery_or_service_text = "proof of delivery or service text";
+$request->invoice_or_receipt_file = "file_id";
+$request->invoice_or_receipt_text = "Copy of the invoice";
+$request->customer_communication_file = "file_id";
+$request->customer_communication_text = "Copy of an email exchange with the cardholder";
+$request->additional_evidence_file = "file_id";
+$request->additional_evidence_text = "Scanned document";
+
+try {
+    $api->getDisputesClient()->putEvidence("dispute_id", $request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/event-types/get.php
+++ b/abc_spec/code_samples/PHP/event-types/get.php
@@ -1,0 +1,33 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    /*
+       Specify API version:
+        "1.0" => Legacy API
+        "2.0" => Unified Payments API
+        null  => all versions
+    */
+    $response = $api->getEventsClient()->retrieveAllEventTypes();
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/events/get.php
+++ b/abc_spec/code_samples/PHP/events/get.php
@@ -1,0 +1,37 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Disputes\\DisputesQueryFilter;
+use Checkout\\Environment;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$request = new DisputesQueryFilter();
+$request->payment_id = "payment_id";
+$request->charge_id = "payment_arn";
+$request->reference = "reference";
+$request->limit = 10;
+$request->skip = 5;
+$request->from = new DateTime();
+$request->to = new DateTime();
+
+try {
+    $response = $api->getEventsClient()->retrieveEvents($request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/events@{eventId}/get.php
+++ b/abc_spec/code_samples/PHP/events@{eventId}/get.php
@@ -1,0 +1,27 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $response = $api->getEventsClient()->retrieveEvent("event_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/events@{eventId}@notifications@{notificationId}/get.php
+++ b/abc_spec/code_samples/PHP/events@{eventId}@notifications@{notificationId}/get.php
@@ -1,0 +1,28 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $response = $api->getEventsClient()->retrieveEventNotification("event_id", "notification_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}
+

--- a/abc_spec/code_samples/PHP/events@{eventId}@webhooks@retry/post.php
+++ b/abc_spec/code_samples/PHP/events@{eventId}@webhooks@retry/post.php
@@ -1,0 +1,27 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $api->getEventsClient()->retryAllWebhooks("event_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/events@{eventId}@webhooks@{webhookId}@retry/post.php
+++ b/abc_spec/code_samples/PHP/events@{eventId}@webhooks@{webhookId}@retry/post.php
@@ -1,0 +1,27 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $api->getEventsClient()->retryWebhook("event_id", "webhook_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/files/post.php
+++ b/abc_spec/code_samples/PHP/files/post.php
@@ -1,0 +1,31 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$fileRequest = new FileRequest();
+$fileRequest->file = "path/to/file"
+$fileRequest->purpose = "dispute_evidence";
+
+try {
+    $response = $api->getDisputesClient()->uploadFile($fileRequest);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/files@{file_id}/get.php
+++ b/abc_spec/code_samples/PHP/files@{file_id}/get.php
@@ -1,0 +1,27 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $response = $api->getDisputesClient()->getFileDetails("file_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/hosted-payments/post.php
+++ b/abc_spec/code_samples/PHP/hosted-payments/post.php
@@ -1,0 +1,119 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Common\\Address;
+use Checkout\\Common\\Country;
+use Checkout\\Common\\Currency;
+use Checkout\\Common\\CustomerRequest;
+use Checkout\\Common\\PaymentSourceType;
+use Checkout\\Common\\Phone;
+use Checkout\\Common\\Product;
+use Checkout\\Environment;
+use Checkout\\Payments\\BillingDescriptor;
+use Checkout\\Payments\\BillingInformation;
+use Checkout\\Payments\\Hosted\\HostedPaymentsSessionRequest;
+use Checkout\\Payments\\PaymentRecipient;
+use Checkout\\Payments\\PaymentType;
+use Checkout\\Payments\\ProcessingSettings;
+use Checkout\\Payments\\RiskRequest;
+use Checkout\\Payments\\ShippingDetails;
+use Checkout\\Payments\\ThreeDsRequest;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$phone = new Phone();
+$phone->country_code = "+1";
+$phone->number = "415 555 2671";
+
+$address = new Address();
+$address->address_line1 = "CheckoutSdk.com";
+$address->address_line2 = "90 Tottenham Court Road";
+$address->city = "London";
+$address->state = "London";
+$address->zip = "W1T 4TJ";
+$address->country = Country::$GB;
+
+$customerRequest = new CustomerRequest();
+$customerRequest->email = "email@docs.checkout.com"
+$customerRequest->name = "Name";
+
+$billingInformation = new BillingInformation();
+$billingInformation->address = $address;
+$billingInformation->phone = $phone;
+
+$shippingDetails = new ShippingDetails();
+$shippingDetails->address = $address;
+$shippingDetails->phone = $phone;
+
+$recipient = new PaymentRecipient();
+$recipient->account_number = "1234567";
+$recipient->country = Country::$ES;
+$recipient->dob = "1985-05-15";
+$recipient->first_name = "FirstName";
+$recipient->last_name = "LastName";
+$recipient->zip = "12345";
+
+$product = new Product();
+$product->name = "Product";
+$product->quantity = 1;
+$product->price = 10;
+
+$products = array($product);
+
+$theeDsRequest = new ThreeDsRequest();
+$theeDsRequest->enabled = false;
+$theeDsRequest->attempt_n3d = false;
+
+$processing = new ProcessingSettings();
+$processing->aft = true;
+
+$risk = new RiskRequest();
+$risk->enabled = false;
+
+$billingDescriptor = new BillingDescriptor();
+$billingDescriptor->city = "London";
+$billingDescriptor->name = "Awesome name";
+
+$request = new HostedPaymentsSessionRequest();
+$request->amount = 100;
+$request->reference = "reference";
+$request->currency = Currency::$GBP;
+$request->description = "Payment for Gold Necklace";
+$request->customer = $customerRequest;
+$request->shipping = $shippingDetails;
+$request->billing = $billingInformation;
+$request->recipient = $recipient;
+$request->processing = $processing;
+$request->products = $products;
+$request->risk = $risk;
+$request->success_url = "https://example.com/payments/success";
+$request->cancel_url = "https://example.com/payments/cancel";
+$request->failure_url = "https://example.com/payments/failure";
+$request->locale = "en-GB";
+$request->three_ds = $theeDsRequest;
+$request->capture = true;
+$request->payment_type = PaymentType::$regular;
+$request->billing_descriptor = $billingDescriptor;
+$request->allow_payment_methods = array(PaymentSourceType::$card, PaymentSourceType::$ideal);
+
+try {
+    $response = $api->getHostedPaymentsClient()->createHostedPaymentsPageSession($request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}
+

--- a/abc_spec/code_samples/PHP/hosted-payments@{id}/get.php
+++ b/abc_spec/code_samples/PHP/hosted-payments@{id}/get.php
@@ -1,0 +1,27 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $response = $api->getHostedPaymentsClient()->getHostedPaymentsPageDetails("hosted_payment_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/instruments/post.php
+++ b/abc_spec/code_samples/PHP/instruments/post.php
@@ -1,0 +1,62 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Common\\Address;
+use Checkout\\Common\\Country;
+use Checkout\\Common\\InstrumentType;
+use Checkout\\Common\\Phone;
+use Checkout\\Environment;
+use Checkout\\Instruments\\CreateInstrumentRequest;
+use Checkout\\Instruments\\InstrumentAccountHolder;
+use Checkout\\Instruments\\InstrumentCustomerRequest;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$address = new Address();
+$address->address_line1 = "CheckoutSdk.com";
+$address->address_line2 = "90 Tottenham Court Road";
+$address->city = "London";
+$address->state = "London";
+$address->zip = "W1T 4TJ";
+$address->country = Country::$GB;
+
+$phone = new Phone();
+$phone->country_code = "+1";
+$phone->number = "415 555 2671";
+
+$instrumentAccountHolder = new InstrumentAccountHolder();
+$instrumentAccountHolder->billing_address = $address;
+$instrumentAccountHolder->phone = $phone;
+
+$customer = new InstrumentCustomerRequest();
+$customer->email = "email@docs.checkout.com";
+$customer->name = "Name";
+$customer->phone = $phone;
+$customer->default = true;
+
+$request = new CreateInstrumentRequest();
+$request->type = InstrumentType::$token;
+$request->token = "token";
+$request->account_holder = $instrumentAccountHolder;
+$request->customer = $customer;
+
+try {
+    $response = $api->getInstrumentsClient()->create($request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/instruments@{id}/delete.php
+++ b/abc_spec/code_samples/PHP/instruments@{id}/delete.php
@@ -1,0 +1,28 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+
+try {
+    $api->getInstrumentsClient()->delete("instrument_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/instruments@{id}/get.php
+++ b/abc_spec/code_samples/PHP/instruments@{id}/get.php
@@ -1,0 +1,27 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $response = $api->getInstrumentsClient()->get("instrument_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/instruments@{id}/patch.php
+++ b/abc_spec/code_samples/PHP/instruments@{id}/patch.php
@@ -1,0 +1,31 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+use Checkout\\Instruments\\UpdateInstrumentRequest;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$request = new UpdateInstrumentRequest();
+$request->name = "testing";
+
+try {
+    $response = $api->getInstrumentsClient()->update("instrument_id", $request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/payment-links/post.php
+++ b/abc_spec/code_samples/PHP/payment-links/post.php
@@ -1,0 +1,105 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Common\\Address;
+use Checkout\\Common\\Country;
+use Checkout\\Common\\Currency;
+use Checkout\\Common\\CustomerRequest;
+use Checkout\\Common\\Phone;
+use Checkout\\Common\\Product;
+use Checkout\\Environment;
+use Checkout\\Payments\\BillingInformation;
+use Checkout\\Payments\\Links\\PaymentLinkRequest;
+use Checkout\\Payments\\PaymentRecipient;
+use Checkout\\Payments\\ProcessingSettings;
+use Checkout\\Payments\\RiskRequest;
+use Checkout\\Payments\\ShippingDetails;
+use Checkout\\Payments\\ThreeDsRequest;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$phone = new Phone();
+$phone->country_code = "+1";
+$phone->number = "415 555 2671";
+
+$address = new Address();
+$address->address_line1 = "CheckoutSdk.com";
+$address->address_line2 = "90 Tottenham Court Road";
+$address->city = "London";
+$address->state = "London";
+$address->zip = "W1T 4TJ";
+$address->country = Country::$GB;
+
+$customerRequest = new CustomerRequest();
+$customerRequest->email = "";
+$customerRequest->name = "Name";
+
+$billingInformation = new BillingInformation();
+$billingInformation->address = $address;
+$billingInformation->phone = $phone;
+
+$shippingDetails = new ShippingDetails();
+$shippingDetails->address = $address;
+$shippingDetails->phone = $phone;
+
+$recipient = new PaymentRecipient();
+$recipient->account_number = "1234567";
+$recipient->country = Country::$ES;
+$recipient->dob = "1985-05-15";
+$recipient->first_name = "First";
+$recipient->last_name = "Last";
+$recipient->zip = "12345";
+
+$product = new Product();
+$product->name = "Product";
+$product->quantity = 1;
+$product->price = 10;
+
+$products = array($product);
+
+$theeDsRequest = new ThreeDsRequest();
+$theeDsRequest->enabled = false;
+$theeDsRequest->attempt_n3d = false;
+
+$processing = new ProcessingSettings();
+$processing->aft = true;
+
+$risk = new RiskRequest();
+$risk->enabled = false;
+
+$request = new PaymentLinkRequest();
+$request->amount = 1000;
+$request->reference = "reference";
+$request->currency = Currency::$GBP;
+$request->description = "Description";
+$request->customer = $customerRequest;
+$request->shipping = $shippingDetails;
+$request->billing = $billingInformation;
+$request->recipient = $recipient;
+$request->processing = $processing;
+$request->products = $products;
+$request->risk = $risk;
+$request->locale = "en-GB";
+$request->three_ds = $theeDsRequest;
+$request->capture = true;
+
+try {
+    $response = $api->getPaymentLinksClient()->createPaymentLink($request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/payment-links@{id}/get.php
+++ b/abc_spec/code_samples/PHP/payment-links@{id}/get.php
@@ -1,0 +1,27 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $response = $api->getPaymentLinksClient()->getPaymentLink("payment_link_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/payments@{id}/get.php
+++ b/abc_spec/code_samples/PHP/payments@{id}/get.php
@@ -1,13 +1,27 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
 <?php
 
-$checkout = new CheckoutApi('your secret key');
-$threeDsSessionId = 'sid_y3oqhf46pyzuxjbcn2giaqnb44';
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
 
 try {
-
-	$details = $checkout->payments()->details($threeDsSessionId);
-	return $details->getSourceId();
-
-} catch(CheckoutHttpException $ex) {
-	return $ex->getErrors();
+    $response = $api->getPaymentsClient()->getPaymentDetails("payment_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
 }

--- a/abc_spec/code_samples/PHP/payments@{id}@actions/get.php
+++ b/abc_spec/code_samples/PHP/payments@{id}@actions/get.php
@@ -1,6 +1,27 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
 <?php
 
-$checkout = new CheckoutApi('your secret key');
-$paymentID = 'pay_y3oqhf46pyzuxjbcn2giaqnb44';
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
 
-return $checkout->payments()->actions($paymentID);
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $response = $api->getPaymentsClient()->getPaymentActions("payment_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/payments@{id}@captures/post.php
+++ b/abc_spec/code_samples/PHP/payments@{id}@captures/post.php
@@ -1,14 +1,33 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
 <?php
 
-$checkout = new CheckoutApi('your secret key');
-$paymentID = 'pay_y3oqhf46pyzuxjbcn2giaqnb44';
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+use Checkout\\Payments\\CaptureRequest;
 
-// Full capture
-$capture = new Capture($paymentID);
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
 
-// Or partial capture
-$capture = new Capture($paymentID);
-$capture->reference = 'your reference';
-$capture->amount = 100;
+$request = new CaptureRequest();
+$request->reference = "reference";
+$request->amount = 5;
 
-return $checkout->payments()->capture($capture);
+try {
+    // or, capturePayment("payment_id") for a full capture
+    $response = $api->getPaymentsClient()->capturePayment("payment_id", $request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/payments@{id}@refunds/post.php
+++ b/abc_spec/code_samples/PHP/payments@{id}@refunds/post.php
@@ -1,14 +1,33 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
 <?php
 
-$checkout = new CheckoutApi('your secret key');
-$paymentID = 'pay_y3oqhf46pyzuxjbcn2giaqnb44';
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+use Checkout\\Payments\\RefundRequest;
 
-// Full refund
-$refund = new Refund($paymentID);
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
 
-// Or partial refund
-$refund = new Refund($paymentID);
-$refund->reference = 'your reference';
-$refund->amount = 100;
+$request = new RefundRequest();
+$request->reference = "reference";
+$request->amount = $amount;
 
-return $checkout->payments()->refund($refund);
+try {
+    // or, refundPayment("payment_id") for a full refund
+    $response = $api->getPaymentsClient()->refundPayment("payment_id", $request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/payments@{id}@voids/post.php
+++ b/abc_spec/code_samples/PHP/payments@{id}@voids/post.php
@@ -1,6 +1,32 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
 <?php
 
-$checkout = new CheckoutApi('your secret key');
-$paymentID = 'pay_y3oqhf46pyzuxjbcn2giaqnb44';
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+use Checkout\\Payments\\VoidRequest;
 
-return $checkout->payments()->void(new Voids($paymentID));
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$request = new VoidRequest();
+$request->reference = "reference";
+
+try {
+    // or, voidPayment("payment_id")
+    $response = $api->getPaymentsClient()->voidPayment("payment_id", $request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/risk@assessments@pre-authentication/post.php
+++ b/abc_spec/code_samples/PHP/risk@assessments@pre-authentication/post.php
@@ -1,0 +1,75 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$address = new Address();
+$address->address_line1 = "CheckoutSdk.com";
+$address->address_line2 = "90 Tottenham Court Road";
+$address->city = "London";
+$address->state = "London";
+$address->zip = "W1T 4TJ";
+$address->country = Country::$GB;
+
+$cardSourcePrism = new CardSourcePrism();
+$cardSourcePrism->billing_address = $address;
+$cardSourcePrism->expiry_month = 10;
+$cardSourcePrism->expiry_year = 2027;
+$cardSourcePrism->number = "number";
+
+$customerRequest = new CustomerRequest();
+$customerRequest->email = "email@docs.checkout.com";
+$customerRequest->name = "Name";
+
+$riskPayment = new RiskPayment();
+$riskPayment->psp = "psp";
+$riskPayment->id = "78453878";
+
+$riskShippingDetails = new RiskShippingDetails();
+$riskShippingDetails->address = $address;
+
+$location = new Location();
+$location->latitude = "51.5107";
+$location->longitude = "0.1313";
+
+$device = new Device();
+$device->location = $location;
+$device->type = "Phone";
+$device->os = "ISO";
+$device->model = "iPhone X";
+$device->date = new DateTime();
+$device->user_agent = "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1";
+$device->fingerprint = "34304a9e3fg09302";
+
+$request = new PreAuthenticationAssessmentRequest();
+$request->date = new DateTime();
+$request->source = $cardSourcePrism;
+$request->customer = $customerRequest;
+$request->payment = $riskPayment;
+$request->shipping = $riskShippingDetails;
+$request->reference = "ORD-1011-87AH";
+$request->description = "Set of 3 masks";
+$request->amount = 10;
+$request->currency = Currency::$GBP;
+$request->device = $device;
+$request->metadata = array("VoucherCode" => "loyalty_10", "discountApplied" => "10", "customer_id" => "2190EF321");
+
+try {
+    $response = $api->getRiskClient()->requestPreAuthenticationRiskScan($request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/risk@assessments@pre-capture/post.php
+++ b/abc_spec/code_samples/PHP/risk@assessments@pre-capture/post.php
@@ -1,0 +1,69 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$customerRequest = new CustomerRequest();
+$customerRequest->email = "email@docs.checkout.com";
+$customerRequest->name = "name";
+
+$riskPayment = new RiskPayment();
+$riskPayment->psp = "psp";
+$riskPayment->id = "78453878";
+
+$riskShippingDetails = new RiskShippingDetails();
+$riskShippingDetails->address = $address;
+
+$authenticationResult = new AuthenticationResult();
+$authenticationResult->attempted = true;
+$authenticationResult->challenged = true;
+$authenticationResult->liability_shifted = true;
+$authenticationResult->method = "3ds";
+$authenticationResult->succeeded = true;
+$authenticationResult->version = "2.0";
+
+$authorizationResult = new AuthorizationResult();
+$authorizationResult->avs_code = "V";
+$authorizationResult->cvv_result = "N";
+
+$device = new Device();
+$device->location = $location;
+$device->type = "Phone";
+$device->os = "ISO";
+$device->model = "iPhone X";
+$device->date = new DateTime();
+$device->user_agent = "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1";
+$device->fingerprint = "34304a9e3fg09302";
+
+$request = new PreCaptureAssessmentRequest();
+$request->date = new DateTime();
+$request->source = $requestSource;
+$request->customer = $customerRequest;
+$request->payment = $riskPayment;
+$request->shipping = $riskShippingDetails;
+$request->amount = 6540;
+$request->currency = Currency::$GBP;
+$request->device = $device;
+$request->metadata = array("VoucherCode" => "loyalty_10", "discountApplied" => "10", "customer_id" => "2190EF321");
+$request->authentication_result = $authenticationResult;
+$request->authorization_result = $authorizationResult;
+
+try {
+    $response = $api->getRiskClient()->requestPreCaptureRiskScan($request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/sources/post.php
+++ b/abc_spec/code_samples/PHP/sources/post.php
@@ -1,0 +1,56 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Common\\Address;
+use Checkout\\Common\\Country;
+use Checkout\\Common\\Phone;
+use Checkout\\Environment;
+use Checkout\\Sources\\SepaSourceRequest;
+use Checkout\\Sources\\SourceData;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$phone = new Phone();
+$phone->country_code = "44";
+$phone->number = "020 222333";
+
+$address = new Address();
+$address->address_line1 = "CheckoutSdk.com";
+$address->address_line2 = "90 Tottenham Court Road";
+$address->city = "London";
+$address->state = "London";
+$address->zip = "W1T 4TJ";
+$address->country = Country::$GB;
+
+$sourceData = new SourceData();
+$sourceData->first_name = "FirstName";
+$sourceData->last_name = "LastName";
+$sourceData->account_iban = "IBAN";
+$sourceData->bic = "BIC";
+$sourceData->billing_descriptor = "descriptor";
+$sourceData->mandate_type = "single";
+
+$request = new SepaSourceRequest();
+$request->billing_address = $address;
+$request->phone = $phone;
+$request->reference = "reference";
+$request->source_data = $sourceData;
+
+try {
+    $response = $api->getSourcesClient()->createSepaSource($request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/tokens/post.php
+++ b/abc_spec/code_samples/PHP/tokens/post.php
@@ -1,0 +1,51 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Common\\Address;
+use Checkout\\Common\\Country;
+use Checkout\\Common\\Phone;
+use Checkout\\Environment;
+use Checkout\\Sources\\SepaSourceRequest;
+use Checkout\\Sources\\SourceData;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$phone = new Phone();
+$phone->country_code = "+1";
+$phone->number = "415 555 2671";
+
+$address = new Address();
+$address->address_line1 = "CheckoutSdk.com";
+$address->address_line2 = "90 Tottenham Court Road";
+$address->city = "London";
+$address->state = "London";
+$address->zip = "W1T 4TJ";
+$address->country = Country::$GB;
+
+$request = new CardTokenRequest();
+$request->name = "Name";
+$request->number = "123456789";
+$request->expiry_year = 2027;
+$request->expiry_month = 10;
+$request->cvv = "123";
+$request->billing_address = $address;
+$request->phone = $phone;
+
+try {
+    $response = $api->getTokensClient()->requestCardToken($request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/webhooks/get.php
+++ b/abc_spec/code_samples/PHP/webhooks/get.php
@@ -1,0 +1,27 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $response = $api->getWebhooksClient()->retrieveWebhooks();
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/webhooks/post.php
+++ b/abc_spec/code_samples/PHP/webhooks/post.php
@@ -1,0 +1,34 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+use Checkout\\Webhooks\\WebhookRequest;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$request = new WebhookRequest();
+$request->url = "https://test.checkout.com/webhooks";
+$request->content_type = "json";
+$request->event_types = array("invoice.cancelled", "card.updated");
+$request->active = true;
+
+try {
+    $response = $api->getWebhooksClient()->registerWebhook($request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/webhooks@{id}/delete.php
+++ b/abc_spec/code_samples/PHP/webhooks@{id}/delete.php
@@ -1,0 +1,27 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $api->getWebhooksClient()->removeWebhook("webhook_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/webhooks@{id}/get.php
+++ b/abc_spec/code_samples/PHP/webhooks@{id}/get.php
@@ -1,0 +1,27 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $response = $api->getWebhooksClient()->retrieveWebhook("webhook_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/webhooks@{id}/patch.php
+++ b/abc_spec/code_samples/PHP/webhooks@{id}/patch.php
@@ -1,0 +1,35 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+use Checkout\\Webhooks\\WebhookRequest;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$request = new WebhookRequest();
+$request->url = "https://test.checkout.com/webhooks/changed";
+$request->headers = [];
+$request->content_type = "json";
+$request->event_types = array("source_updated");
+$request->active = true;
+
+try {
+    $response = $api->getWebhooksClient()->patchWebhook("webhookId", $request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/abc_spec/code_samples/PHP/webhooks@{id}/put.php
+++ b/abc_spec/code_samples/PHP/webhooks@{id}/put.php
@@ -1,0 +1,35 @@
+// For more information please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutDefaultSdk;
+use Checkout\\Environment;
+use Checkout\\Webhooks\\WebhookRequest;
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$request = new WebhookRequest();
+$request->url = "https://test.checkout.com/webhooks/changed";
+$request->headers = [];
+$request->content_type = "json";
+$request->event_types = array("source_updated");
+$request->active = true;
+
+try {
+    $response = $api->getWebhooksClient()->updateWebhook("webhook_id", $request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/changelog.md
+++ b/nas_spec/changelog.md
@@ -2,7 +2,8 @@
 
 | Date       | Description of change                                                                                                 |
 | ---------- | --------------------------------------------------------------------------------------------------------------------- |
-| 2022/03/22 | Added new scheme `cartes_bancaires` to enum `scheme` in Get and Create Sessions Responses                                                                           |
+| 2022/03/28 | Update PHP code samples                                                                                               |
+| 2022/03/22 | Added new scheme `cartes_bancaires` to enum `scheme` in Get and Create Sessions Responses                             |
 | 2022/03/22 | Fixed invalid format for `authentication_date`                                                                        |
 | 2022/03/18 | Added Cartes Bancaires changes to Sessions request and response.                                                      |
 | 2022/03/16 | Adds `document` object to the `company` object in the Marketplace API                                                 |

--- a/nas_spec/code_samples/PHP/connect@token/post.php
+++ b/nas_spec/code_samples/PHP/connect@token/post.php
@@ -1,0 +1,21 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Files, FourOAuthScope::$Flow, FourOAuthScope::$Fx, FourOAuthScope::$Gateway,
+    FourOAuthScope::$Marketplace, FourOAuthScope::$SessionsApp, FourOAuthScope::$SessionsBrowser,
+    FourOAuthScope::$Vault, FourOAuthScope::$PayoutsBankDetails]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();

--- a/nas_spec/code_samples/PHP/customers/post.php
+++ b/nas_spec/code_samples/PHP/customers/post.php
@@ -1,0 +1,49 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Common\\Phone;
+use Checkout\\Customers\\Four\\CustomerRequest;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+
+// API Keys
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Gateway]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$phone = new Phone();
+$phone->country_code = "+1";
+$phone->number = "415 555 2671";
+
+$request = new CustomerRequest();
+$request->email = "email@docs.checkout.com";
+$request->name = "name";
+$request->phone = $phone;
+$request->instruments = ["instrument_id_1", "instrument_id_2"];
+
+try {
+    $response = $api->getCustomersClient()->create($request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/customers@{identifier}/delete.php
+++ b/nas_spec/code_samples/PHP/customers@{identifier}/delete.php
@@ -1,0 +1,37 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+
+// API Keys
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Gateway]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $api->getCustomersClient()->delete("customer_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/customers@{identifier}/get.php
+++ b/nas_spec/code_samples/PHP/customers@{identifier}/get.php
@@ -1,0 +1,37 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+
+// API Keys
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Gateway]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $response = $api->getCustomersClient()->get("customer_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/customers@{identifier}/patch.php
+++ b/nas_spec/code_samples/PHP/customers@{identifier}/patch.php
@@ -1,0 +1,44 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+
+// API Keys
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Gateway]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$phone = new Phone();
+$phone->country_code = "+1";
+$phone->number = "415 555 2671";
+
+$request = new CustomerRequest();
+$request->email = "email@docs.checkout.com";
+$request->name = "name";
+$request->phone = $phone;
+$request->instruments = ["instrument_id_1", "instrument_id_2"];
+
+try {
+    $api->getCustomersClient()->update("customer_id", $request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/disputes/get.php
+++ b/nas_spec/code_samples/PHP/disputes/get.php
@@ -1,0 +1,51 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+
+// API Keys
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Disputes]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$query = new DisputesQueryFilter();
+$query->payment_id = "payment_id";
+$query->payment_arn = "payment_arn";
+$query->payment_reference = "payment_reference";
+$query->statuses = "comma,separated,list,statuses";
+$query->limit = 10;
+$query->skip = 5;
+$query->to = new DateTime(); // UTC, now
+
+$from = new DateTime();
+$from->setTimezone(new DateTimeZone("europe/madrid"));
+$from->sub(new DateInterval("P1Y"));
+$query->from = $from;
+
+try {
+    $response = $api->getDisputesClient()->query($query);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/disputes@{dispute_id}/get.php
+++ b/nas_spec/code_samples/PHP/disputes@{dispute_id}/get.php
@@ -1,0 +1,37 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+
+// API Keys
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Disputes]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $response = $api->getDisputesClient()->getDisputeDetails("dispute_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/disputes@{dispute_id}@accept/post.php
+++ b/nas_spec/code_samples/PHP/disputes@{dispute_id}@accept/post.php
@@ -1,0 +1,38 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+
+// API Keys
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Disputes]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $api->getDisputesClient()->accept("dispute_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}
+

--- a/nas_spec/code_samples/PHP/disputes@{dispute_id}@evidence/get.php
+++ b/nas_spec/code_samples/PHP/disputes@{dispute_id}@evidence/get.php
@@ -1,0 +1,37 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+
+// API Keys
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Disputes]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $response = $api->getDisputesClient()->getEvidence("dispute_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/disputes@{dispute_id}@evidence/post.php
+++ b/nas_spec/code_samples/PHP/disputes@{dispute_id}@evidence/post.php
@@ -1,0 +1,37 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+
+// API Keys
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Disputes]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $api->getDisputesClient()->submitEvidence("dispute_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/disputes@{dispute_id}@evidence/put.php
+++ b/nas_spec/code_samples/PHP/disputes@{dispute_id}@evidence/put.php
@@ -1,0 +1,48 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Disputes\\DisputeEvidenceRequest;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+
+// API Keys
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Disputes]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$request = new DisputeEvidenceRequest();
+$request->proof_of_delivery_or_service_file = "file_id";
+$request->proof_of_delivery_or_service_text = "proof of delivery or service text";
+$request->invoice_or_receipt_file = "file_id";
+$request->invoice_or_receipt_text = "Copy of the invoice";
+$request->customer_communication_file = "file_id";
+$request->customer_communication_text = "Copy of an email exchange with the cardholder";
+$request->additional_evidence_file = "file_id";
+$request->additional_evidence_text = "Scanned document";
+
+try {
+    $api->getDisputesClient()->putEvidence("dispute_id", $request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/files/post.php
+++ b/nas_spec/code_samples/PHP/files/post.php
@@ -1,0 +1,42 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Environment;
+use Checkout\\Files\\FileRequest;
+use Checkout\\Four\\FourOAuthScope;
+
+// API Keys
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Files]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$fileRequest = new FileRequest();
+$fileRequest->file = "path/to/file"
+$fileRequest->purpose = "dispute_evidence";
+
+try {
+    $response = $api->getDisputesClient()->uploadFile($fileRequest);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/files@{file_id}/get.php
+++ b/nas_spec/code_samples/PHP/files@{file_id}/get.php
@@ -1,0 +1,37 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+
+// API Keys
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Files]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $response = $api->getDisputesClient()->getFileDetails("file_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/forex@quotes/post.php
+++ b/nas_spec/code_samples/PHP/forex@quotes/post.php
@@ -1,0 +1,38 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Common\\Currency;
+use Checkout\\Environment;
+use Checkout\\Forex\\QuoteRequest;
+use Checkout\\Four\\FourOAuthScope;
+
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Fx]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$request = new QuoteRequest();
+$request->source_currency = Currency::$GBP;
+$request->source_amount = 30000;
+$request->destination_currency = Currency::$USD;
+$request->process_channel_id = "pc_abcdefghijklmnopqrstuvwxyz";
+
+try {
+    $response = $api->getForexClient()->requestQuote(request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/instruments/post.php
+++ b/nas_spec/code_samples/PHP/instruments/post.php
@@ -1,0 +1,69 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Common\\Address;
+use Checkout\\Common\\Country;
+use Checkout\\Common\\Four\\AccountHolder;
+use Checkout\\Common\\Phone;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+use Checkout\\Instruments\\Four\\Create\\CreateCustomerInstrumentRequest;
+use Checkout\\Instruments\\Four\\Create\\CreateTokenInstrumentRequest;
+
+// API Keys
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Gateway]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$phone = new Phone();
+$phone->country_code = "+1";
+$phone->number = "415 555 2671";
+
+$address = new Address();
+$address->address_line1 = "CheckoutSdk.com";
+$address->address_line2 = "90 Tottenham Court Road";
+$address->city = "London";
+$address->state = "London";
+$address->zip = "W1T 4TJ";
+$address->country = Country::$GB;
+
+$accountHolder = new AccountHolder();
+$accountHolder->first_name = "John";
+$accountHolder->last_name = "Smith";
+$accountHolder->phone = $phone;
+$accountHolder->billing_address = $address;
+
+$createCustomerInstrumentRequest = new CreateCustomerInstrumentRequest();
+$createCustomerInstrumentRequest->id = "customer_id";
+
+$request = new CreateTokenInstrumentRequest();
+$request->token = "token";
+$request->account_holder = $accountHolder;
+$request->customer = $createCustomerInstrumentRequest;
+
+try {
+    $response = $api->getInstrumentsClient()->create($request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/instruments@{id}/delete.php
+++ b/nas_spec/code_samples/PHP/instruments@{id}/delete.php
@@ -1,0 +1,37 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+
+// API Keys
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Gateway]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $api->getInstrumentsClient()->delete("instrument_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/instruments@{id}/get.php
+++ b/nas_spec/code_samples/PHP/instruments@{id}/get.php
@@ -1,0 +1,38 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+
+// API Keys
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Gateway]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $response = $api->getInstrumentsClient()->get("instrument_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}
+

--- a/nas_spec/code_samples/PHP/instruments@{id}/patch.php
+++ b/nas_spec/code_samples/PHP/instruments@{id}/patch.php
@@ -1,0 +1,41 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+use Checkout\\Instruments\\Four\\Update\\UpdateTokenInstrumentRequest;
+
+// API Keys
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Gateway]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$request = new UpdateTokenInstrumentRequest();
+$request->token = "new_token";
+
+try {
+    $response = $api->getInstrumentsClient()->update("instrument_id", $request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/marketplace@entities/post.php
+++ b/nas_spec/code_samples/PHP/marketplace@entities/post.php
@@ -1,0 +1,75 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Common\\Address;
+use Checkout\\Common\\Country;
+use Checkout\\Common\\Phone;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+use Checkout\\Marketplace\\ContactDetails;
+use Checkout\\Marketplace\\DateOfBirth;
+use Checkout\\Marketplace\\Identification;
+use Checkout\\Marketplace\\Individual;
+use Checkout\\Marketplace\\OnboardEntityRequest;
+use Checkout\\Marketplace\\Profile;
+
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Marketplace]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$phone = new Phone();
+$phone->country_code = "+1";
+$phone->number = "415 555 2671";
+
+$address = new Address();
+$address->address_line1 = "CheckoutSdk.com";
+$address->address_line2 = "90 Tottenham Court Road";
+$address->city = "London";
+$address->state = "London";
+$address->zip = "W1T 4TJ";
+$address->country = Country::$GB;
+
+$dateOfBirth = new DateOfBirth();
+$dateOfBirth->day = 5;
+$dateOfBirth->month = 6;
+$dateOfBirth->year = 1996;
+
+$identification = new Identification();
+$identification->national_id_number = "AB123456C";
+
+$request = new OnboardEntityRequest();
+$request->reference = "reference";
+$request->contact_details = new ContactDetails();
+$request->contact_details->phone = $phone;
+$request->profile = new Profile();
+$request->profile->urls = array("https://docs.checkout.com");
+$request->profile->mccs = array("0742");
+$request->individual = new Individual();
+$request->individual->first_name = "FirstName";
+$request->individual->last_name = "LastName";
+$request->individual->trading_name = "Trading";
+$request->individual->registered_address = $address;
+$request->individual->national_tax_id = "TAX123456";
+$request->individual->date_of_birth = $dateOfBirth;
+$request->individual->identification = $identification;
+
+try {
+    $response = $api->getMarketplaceClient()->createEntity($request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/marketplace@entities@{id}/get.php
+++ b/nas_spec/code_samples/PHP/marketplace@entities@{id}/get.php
@@ -1,0 +1,30 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Marketplace]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $response = $api->getMarketplaceClient()->getEntity("entity_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/marketplace@entities@{id}/put.php
+++ b/nas_spec/code_samples/PHP/marketplace@entities@{id}/put.php
@@ -1,0 +1,75 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Common\\Address;
+use Checkout\\Common\\Country;
+use Checkout\\Common\\Phone;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+use Checkout\\Marketplace\\ContactDetails;
+use Checkout\\Marketplace\\DateOfBirth;
+use Checkout\\Marketplace\\Identification;
+use Checkout\\Marketplace\\Individual;
+use Checkout\\Marketplace\\OnboardEntityRequest;
+use Checkout\\Marketplace\\Profile;
+
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Marketplace]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$phone = new Phone();
+$phone->country_code = "+1";
+$phone->number = "415 555 2671";
+
+$address = new Address();
+$address->address_line1 = "CheckoutSdk.com";
+$address->address_line2 = "90 Tottenham Court Road";
+$address->city = "London";
+$address->state = "London";
+$address->zip = "W1T 4TJ";
+$address->country = Country::$GB;
+
+$dateOfBirth = new DateOfBirth();
+$dateOfBirth->day = 5;
+$dateOfBirth->month = 6;
+$dateOfBirth->year = 1996;
+
+$identification = new Identification();
+$identification->national_id_number = "AB123456C";
+
+$request = new OnboardEntityRequest();
+$request->reference = "reference";
+$request->contact_details = new ContactDetails();
+$request->contact_details->phone = $phone;
+$request->profile = new Profile();
+$request->profile->urls = array("https://docs.checkout.com");
+$request->profile->mccs = array("0742");
+$request->individual = new Individual();
+$request->individual->first_name = "FirstName";
+$request->individual->last_name = "LastName";
+$request->individual->trading_name = "Trading";
+$request->individual->registered_address = $address;
+$request->individual->national_tax_id = "TAX123456";
+$request->individual->date_of_birth = $dateOfBirth;
+$request->individual->identification = $identification;
+
+try {
+    $response = $api->getMarketplaceClient()->updateEntity("entity_id", $request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/marketplace@entities@{id}@instruments/post.php
+++ b/nas_spec/code_samples/PHP/marketplace@entities@{id}@instruments/post.php
@@ -1,0 +1,50 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Common\\Country;
+use Checkout\\Common\\Currency;
+use Checkout\\Common\\Four\\AccountType;
+use Checkout\\Common\\Four\\BankDetails;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+use Checkout\\Marketplace\\InstrumentDocument;
+use Checkout\\Marketplace\\MarketplacePaymentInstrument;
+
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Marketplace]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$request = new MarketplacePaymentInstrument();
+$request->account_number = "123456789";
+$request->account_type = AccountType::$cash;
+$request->bank = new BankDetails();
+$request->bank_code = "bank_code";
+$request->bban = "bban";
+$request->branch_code = "123";
+$request->country = Country::$GB;
+$request->currency = Currency::$GBP;
+$request->document = new InstrumentDocument();
+$request->iban = "iban";
+$request->label = "mkt-1";
+$request->swift_bic = "BIC";
+
+try {
+    $api->getMarketplaceClient()->createPaymentInstrument("entity_id", $request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/payments/post.php
+++ b/nas_spec/code_samples/PHP/payments/post.php
@@ -1,27 +1,92 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
 <?php
 
-$checkout = new CheckoutApi('your secret key');
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Common\\Address;
+use Checkout\\Common\\Country;
+use Checkout\\Common\\Currency;
+use Checkout\\Common\\CustomerRequest;
+use Checkout\\Common\\Phone;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+use Checkout\\Payments\\Four\\Request\\PaymentRequest;
+use Checkout\\Payments\\Four\\Request\\Source\\RequestCardSource;
+use Checkout\\Payments\\Four\\Sender\\Identification;
+use Checkout\\Payments\\Four\\Sender\\IdentificationType;
+use Checkout\\Payments\\Four\\Sender\\PaymentIndividualSender;
 
-$method = new TokenSource('tok_ubfj2q76miwundwlk72vxt2i7q');
-$payment = new Payment($method, 'USD');
+// API Keys
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
 
-$payment->amount = 5600;
-$payment->capture = false;
-$payment->reference = 'ORD-090857';
-$payment->threeDs = new ThreeDs(true);
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Gateway]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$phone = new Phone();
+$phone->country_code = "+1";
+$phone->number = "415 555 2671";
+
+$address = new Address();
+$address->address_line1 = "CheckoutSdk.com";
+$address->address_line2 = "90 Tottenham Court Road";
+$address->city = "London";
+$address->state = "London";
+$address->zip = "W1T 4TJ";
+$address->country = Country::$GB;
+
+$requestCardSource = new RequestCardSource();
+$requestCardSource->name = "Name";
+$requestCardSource->number = "Number";
+$requestCardSource->expiry_year = 2026;
+$requestCardSource->expiry_month = 10;
+$requestCardSource->cvv = "123";
+$requestCardSource->billing_address = $address;
+$requestCardSource->phone = $phone;
+
+$customerRequest = new CustomerRequest();
+$customerRequest->email = "email@docs.checkout.com";
+$customerRequest->name = "Customer";
+
+$identification = new Identification();
+$identification->issuing_country = Country::$GT;
+$identification->number = "1234";
+$identification->type = IdentificationType::$drivingLicence;
+
+$paymentIndividualSender = new PaymentIndividualSender();
+$paymentIndividualSender->fist_name = "FirstName";
+$paymentIndividualSender->last_name = "LastName";
+$paymentIndividualSender->address = $address;
+$paymentIndividualSender->identification = $identification;
+
+$request = new PaymentRequest();
+$request->source = $requestCardSource;
+$request->capture = true;
+$request->reference = "reference";
+$request->amount = 10;
+$request->currency = Currency::$USD;
+$request->customer = $customerRequest;
+$request->sender = $paymentIndividualSender;
 
 try {
-    $details = $checkout->payments()->request($payment);
-
-    $redirection = $details->getRedirection();
-    if ($redirection) {
-        return $redirection;
-    }
-
-    return $details;
-
-} catch (CheckoutModelException $ex) {
-    return $ex->getErrors();
-} catch (CheckoutHttpException $ex) {
-    return $ex->getErrors();
+    $response = $api->getPaymentsClient()->requestPayment($request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
 }

--- a/nas_spec/code_samples/PHP/payments@{id}/get.php
+++ b/nas_spec/code_samples/PHP/payments@{id}/get.php
@@ -1,13 +1,37 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
 <?php
 
-$checkout = new CheckoutApi('your secret key');
-$threeDsSessionId = 'sid_y3oqhf46pyzuxjbcn2giaqnb44';
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+
+// API Keys
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Gateway]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
 
 try {
-
-	$details = $checkout->payments()->details($threeDsSessionId);
-	return $details->getSourceId();
-
-} catch(CheckoutHttpException $ex) {
-	return $ex->getErrors();
+    $response = $api->getPaymentsClient()->getPaymentDetails("payment_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
 }

--- a/nas_spec/code_samples/PHP/payments@{id}@actions/get.php
+++ b/nas_spec/code_samples/PHP/payments@{id}@actions/get.php
@@ -1,6 +1,37 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
 <?php
 
-$checkout = new CheckoutApi('your secret key');
-$paymentID = 'pay_y3oqhf46pyzuxjbcn2giaqnb44';
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
 
-return $checkout->payments()->actions($paymentID);
+// API Keys
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Gateway]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $response = $api->getPaymentsClient()->getPaymentActions("payment_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/payments@{id}@authorizations/post.php
+++ b/nas_spec/code_samples/PHP/payments@{id}@authorizations/post.php
@@ -1,0 +1,44 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+use Checkout\\Payments\\Four\\AuthorizationRequest;
+
+// API Keys
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Gateway]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$request = new AuthorizationRequest();
+$request->amount = 10;
+$request->reference = "reference";
+$request->metadata = array("param1" => "value1", "param2" => "value2");
+
+try {
+    // Optional: idempotencyKey as a third parameter for idempotent requests
+    $response = $api->getPaymentsClient()->incrementPaymentAuthorization("payment_id", $request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/payments@{id}@captures/post.php
+++ b/nas_spec/code_samples/PHP/payments@{id}@captures/post.php
@@ -1,14 +1,45 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
 <?php
 
-$checkout = new CheckoutApi('your secret key');
-$paymentID = 'pay_y3oqhf46pyzuxjbcn2giaqnb44';
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+use Checkout\\Payments\\Four\\CaptureRequest;
 
-// Full capture
-$capture = new Capture($paymentID);
+// API Keys
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
 
-// Or partial capture
-$capture = new Capture($paymentID);
-$capture->reference = 'your reference';
-$capture->amount = 100;
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Gateway]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
 
-return $checkout->payments()->capture($capture);
+$request = new CaptureRequest();
+$request->reference = "partial capture";
+$request->amount = 5;
+
+try {
+    // or, capturePayment("payment_id") for a full capture
+    $response = $api->getPaymentsClient()->capturePayment("payment_id", $request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}
+
+

--- a/nas_spec/code_samples/PHP/payments@{id}@refunds/post.php
+++ b/nas_spec/code_samples/PHP/payments@{id}@refunds/post.php
@@ -1,14 +1,43 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
 <?php
 
-$checkout = new CheckoutApi('your secret key');
-$paymentID = 'pay_y3oqhf46pyzuxjbcn2giaqnb44';
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+use Checkout\\Payments\\RefundRequest;
 
-// Full refund
-$refund = new Refund($paymentID);
+// API Keys
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
 
-// Or partial refund
-$refund = new Refund($paymentID);
-$refund->reference = 'your reference';
-$refund->amount = 100;
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Gateway]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
 
-return $checkout->payments()->refund($refund);
+$request = new RefundRequest();
+$request->reference = "reference";
+$request->amount = $amount;
+
+try {
+    // or, refundPayment("payment_id") for a full refund
+    $response = $api->getPaymentsClient()->refundPayment("payment_id", $request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/payments@{id}@voids/post.php
+++ b/nas_spec/code_samples/PHP/payments@{id}@voids/post.php
@@ -1,6 +1,42 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
 <?php
 
-$checkout = new CheckoutApi('your secret key');
-$paymentID = 'pay_y3oqhf46pyzuxjbcn2giaqnb44';
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+use Checkout\\Payments\\VoidRequest;
 
-return $checkout->payments()->void(new Voids($paymentID));
+// API Keys
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+// OAuth
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$Gateway]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$request = new VoidRequest();
+$request->reference = "reference";
+
+try {
+    // or, voidPayment("payment_id")
+    $response = $api->getPaymentsClient()->voidPayment("payment_id", $request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/risk@assessments@pre-authentication/post.php
+++ b/nas_spec/code_samples/PHP/risk@assessments@pre-authentication/post.php
@@ -1,0 +1,80 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Common\\Currency;
+use Checkout\\Environment;
+
+// API Keys
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$address = new Address();
+$address->address_line1 = "CheckoutSdk.com";
+$address->address_line2 = "90 Tottenham Court Road";
+$address->city = "London";
+$address->state = "London";
+$address->zip = "W1T 4TJ";
+$address->country = Country::$GB;
+
+$cardSourcePrism = new CardSourcePrism();
+$cardSourcePrism->billing_address = $address;
+$cardSourcePrism->expiry_month = 10;
+$cardSourcePrism->expiry_year = 2027;
+$cardSourcePrism->number = "number"
+
+$customerRequest = new CustomerRequest();
+$customerRequest->email = "email@docs.checkout.com";
+$customerRequest->name = "Name";
+
+$riskPayment = new RiskPayment();
+$riskPayment->psp = "psp";
+$riskPayment->id = "78453878";
+
+$riskShippingDetails = new RiskShippingDetails();
+$riskShippingDetails->address = $address;
+
+$location = new Location();
+$location->latitude = "51.5107";
+$location->longitude = "0.1313";
+
+$device = new Device();
+$device->location = $location;
+$device->type = "Phone";
+$device->os = "ISO";
+$device->model = "iPhone X";
+$device->date = new DateTime();
+$device->user_agent = "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1";
+$device->fingerprint = "34304a9e3fg09302";
+
+$request = new PreAuthenticationAssessmentRequest();
+$request->date = new DateTime();
+$request->source = $cardSourcePrism;
+$request->customer = $customerRequest;
+$request->payment = $riskPayment;
+$request->shipping = $riskShippingDetails;
+$request->reference = "ORD-1011-87AH";
+$request->description = "Set of 3 masks";
+$request->amount = 10;
+$request->currency = Currency::$GBP;
+$request->device = $device;
+$request->metadata = array("VoucherCode" => "loyalty_10", "discountApplied" => "10", "customer_id" => "2190EF321");
+
+try {
+    $response = $api->getRiskClient()->requestPreAuthenticationRiskScan($request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/risk@assessments@pre-capture/post.php
+++ b/nas_spec/code_samples/PHP/risk@assessments@pre-capture/post.php
@@ -1,0 +1,80 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Common\\Currency;
+use Checkout\\Environment;
+
+// API Keys
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$builder = CheckoutDefaultSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$customerRequest = new CustomerRequest();
+$customerRequest->email = "email@docs.checkout.com";
+$customerRequest->name = "name";
+
+$riskPayment = new RiskPayment();
+$riskPayment->psp = "psp";
+$riskPayment->id = "78453878";
+
+$riskShippingDetails = new RiskShippingDetails();
+$riskShippingDetails->address = $address;
+
+$authenticationResult = new AuthenticationResult();
+$authenticationResult->attempted = true;
+$authenticationResult->challenged = true;
+$authenticationResult->liability_shifted = true;
+$authenticationResult->method = "3ds";
+$authenticationResult->succeeded = true;
+$authenticationResult->version = "2.0";
+
+$authorizationResult = new AuthorizationResult();
+$authorizationResult->avs_code = "V";
+$authorizationResult->cvv_result = "N";
+
+$device = new Device();
+$device->location = $location;
+$device->type = "Phone";
+$device->os = "ISO";
+$device->model = "iPhone X";
+$device->date = new DateTime();
+$device->user_agent = "Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1";
+$device->fingerprint = "34304a9e3fg09302";
+
+$request = new PreCaptureAssessmentRequest();
+$request->date = new DateTime();
+$request->source = $requestSource;
+$request->customer = $customerRequest;
+$request->payment = $riskPayment;
+$request->shipping = $riskShippingDetails;
+$request->amount = 6540;
+$request->currency = Currency::$GBP;
+$request->device = $device;
+$request->metadata = array("VoucherCode" => "loyalty_10", "discountApplied" => "10", "customer_id" => "2190EF321");
+$request->authentication_result = $authenticationResult;
+$request->authorization_result = $authorizationResult;
+
+try {
+    $response = $api->getRiskClient()->requestPreCaptureRiskScan($request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/sessions/post.php
+++ b/nas_spec/code_samples/PHP/sessions/post.php
@@ -1,0 +1,115 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Common\\ChallengeIndicatorType;
+use Checkout\\Common\\Country;
+use Checkout\\Common\\Currency;
+use Checkout\\Common\\Phone;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+use Checkout\\Sessions\\Category;
+use Checkout\\Sessions\\Channel\\AppSession;
+use Checkout\\Sessions\\Channel\\SdkEphemeralPublicKey;
+use Checkout\\Sessions\\Channel\\SdkInterfaceType;
+use Checkout\\Sessions\\Completion\\NonHostedCompletionInfo;
+use Checkout\\Sessions\\SessionAddress;
+use Checkout\\Sessions\\SessionMarketplaceData;
+use Checkout\\Sessions\\SessionRequest;
+use Checkout\\Sessions\\SessionsBillingDescriptor;
+use Checkout\\Sessions\\Source\\SessionCardSource;
+use Checkout\\Sessions\\TransactionType;
+use Checkout\\Sessions\\UIElements;
+
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$SessionsApp, FourOAuthScope::$SessionsBrowser]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$phone = new Phone();
+$phone->country_code = "+1";
+$phone->number = "415 555 2671";
+
+$billingAddress = new SessionAddress();
+$billingAddress->address_line1 = "CheckoutSdk.com";
+$billingAddress->address_line2 = "90 Tottenham Court Road";
+$billingAddress->city = "London";
+$billingAddress->state = "ENG";
+$billingAddress->country = Country::$GB;
+
+$sessionCardSource = new SessionCardSource();
+$sessionCardSource->billing_address = $billingAddress;
+$sessionCardSource->number = "number";
+$sessionCardSource->expiry_month = 10;
+$sessionCardSource->expiry_year = 2026;
+$sessionCardSource->name = "Name";
+$sessionCardSource->email = "email@docs.checkout.com";
+$sessionCardSource->home_phone = $phone;
+$sessionCardSource->work_phone = $phone;
+$sessionCardSource->mobile_phone = $phone;
+
+$shippingAddress = new SessionAddress();
+$shippingAddress->address_line1 = "CheckoutSdk.com";
+$shippingAddress->address_line2 = "90 Tottenham Court Road";
+$shippingAddress->city = "London";
+$shippingAddress->state = "London";
+$shippingAddress->zip = "W1T 4TJ";
+$shippingAddress->country = Country::$GB;
+
+$marketPlaceData = new SessionMarketplaceData();
+$marketPlaceData->sub_entity_id = "ent_123456789";
+
+$billingDescriptor = new SessionsBillingDescriptor();
+$billingDescriptor->name = "Name";
+
+$nonHostedCompletionInfo = new NonHostedCompletionInfo();
+$nonHostedCompletionInfo->callback_url = "https://docs.checkout.com/callback";
+
+$sdkEphemeralPublicKey = new SdkEphemeralPublicKey();
+$sdkEphemeralPublicKey->kty = "EC";
+$sdkEphemeralPublicKey->crv = "P-256";
+$sdkEphemeralPublicKey->x = "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU";
+$sdkEphemeralPublicKey->y = "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0";
+
+$appSession = new AppSession();
+$appSession->sdk_app_id = "dbd64fcb-c19a-4728-8849-e3d50bfdde39";
+$appSession->sdk_max_timeout = 5;
+$appSession->sdk_encrypted_data = "{}";
+$appSession->sdk_ephem_pub_key = $sdkEphemeralPublicKey;
+$appSession->sdk_reference_number = "3DS_LOA_SDK_PPFU_020100_00007";
+$appSession->sdk_transaction_id = "b2385523-a66c-4907-ac3c-91848e8c0067";
+$appSession->sdk_interface_type = SdkInterfaceType::$both;
+$appSession->sdk_ui_elements = array(UIElements::$single_select, UIElements::$html_other);
+
+$request = new SessionRequest();
+$request->source = $sessionCardSource;
+$request->amount = 100;
+$request->currency = Currency::$USD;
+$request->processing_channel_id = "pc_123456789";
+$request->marketplace = $marketPlaceData;
+$request->authentication_category = Category::$payment;
+$request->challenge_indicator = ChallengeIndicatorType::$no_preference;
+$request->billing_descriptor = $billingDescriptor;
+$request->reference = "reference";
+$request->transaction_type = TransactionType::$goods_service;
+$request->shipping_address = $shippingAddress;
+$request->completion = $nonHostedCompletionInfo;
+$request->channel_data = $appSession;
+
+try {
+    $response = $api->getSessionsClient()->requestSession($request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/sessions@{id}/get.php
+++ b/nas_spec/code_samples/PHP/sessions@{id}/get.php
@@ -1,0 +1,29 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$SessionsApp, FourOAuthScope::$SessionsBrowser]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $response = $api->getSessionsClient()->getSessionDetails("session_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/sessions@{id}@collect-data/put.php
+++ b/nas_spec/code_samples/PHP/sessions@{id}@collect-data/put.php
@@ -1,0 +1,44 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+use Checkout\\Sessions\\Channel\\BrowserSession;
+use Checkout\\Sessions\\Channel\\ThreeDsMethodCompletion;
+
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$SessionsApp, FourOAuthScope::$SessionsBrowser]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$browserSession = new BrowserSession();
+$browserSession->accept_header = "Accept:  *.*, q=0.1";
+$browserSession->java_enabled = true;
+$browserSession->language = "FR-fr";
+$browserSession->color_depth = "16";
+$browserSession->screen_width = "1920";
+$browserSession->screen_height = "1080";
+$browserSession->timezone = "60";
+$browserSession->user_agent = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36";
+$browserSession->three_ds_method_completion = ThreeDsMethodCompletion::$y;
+$browserSession->ip_address = "1.12.123.255";
+
+try {
+    $response = $api->getSessionsClient()->updateSession("session_id", $browserSession);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}
+

--- a/nas_spec/code_samples/PHP/sessions@{id}@complete/post.php
+++ b/nas_spec/code_samples/PHP/sessions@{id}@complete/post.php
@@ -1,0 +1,29 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$SessionsApp, FourOAuthScope::$SessionsBrowser]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+try {
+    $api->getSessionsClient()->completeSession("session_id");
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/sessions@{id}@issuer-fingerprint/put.php
+++ b/nas_spec/code_samples/PHP/sessions@{id}@issuer-fingerprint/put.php
@@ -1,0 +1,40 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+use Checkout\\Sessions\\Channel\\ThreeDsMethodCompletion;
+use Checkout\\Sessions\\ThreeDsMethodCompletionRequest;
+
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$SessionsApp, FourOAuthScope::$SessionsBrowser]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$request = new ThreeDsMethodCompletionRequest();
+$request->three_ds_method_completion = ThreeDsMethodCompletion::$y;
+
+try {
+    $api->getSessionsClient()->updateThreeDsMethodCompletionIndicator("session_id", $request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/tokens/post.php
+++ b/nas_spec/code_samples/PHP/tokens/post.php
@@ -1,0 +1,52 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Common\\Address;
+use Checkout\\Common\\Country;
+use Checkout\\Common\\Phone;
+use Checkout\\Environment;
+use Checkout\\Tokens\\CardTokenRequest;
+
+$builder = CheckoutFourSdk::staticKeys();
+$builder->setPublicKey("public_key");
+$builder->setSecretKey("secret_key");
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$phone = new Phone();
+$phone->country_code = "+1";
+$phone->number = "415 555 2671";
+
+$address = new Address();
+$address->address_line1 = "CheckoutSdk.com";
+$address->address_line2 = "90 Tottenham Court Road";
+$address->city = "London";
+$address->state = "London";
+$address->zip = "W1T 4TJ";
+$address->country = Country::$GB;
+
+$request = new CardTokenRequest();
+$request->name = "Name";
+$request->number = "123456789";
+$request->expiry_year = 2027;
+$request->expiry_month = 10;
+$request->cvv = "123";
+$request->billing_address = $address;
+$request->phone = $phone;
+
+try {
+    $response = $api->getTokensClient()->requestCardToken($request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}

--- a/nas_spec/code_samples/PHP/validation@bank-accounts@{country}@{currency}/get.php
+++ b/nas_spec/code_samples/PHP/validation@bank-accounts@{country}@{currency}/get.php
@@ -1,0 +1,33 @@
+// Please refer to https://github.com/checkout/checkout-sdk-php
+<?php
+
+use Checkout\\CheckoutApiException;
+use Checkout\\CheckoutArgumentException;
+use Checkout\\CheckoutAuthorizationException;
+use Checkout\\CheckoutFourSdk;
+use Checkout\\Environment;
+use Checkout\\Four\\FourOAuthScope;
+
+$builder = CheckoutFourSdk::oAuth();
+$builder->clientCredentials("client_id", "client_secret");
+$builder->scopes([FourOAuthScope::$PayoutsBankDetails]); // more scopes available
+$builder->setEnvironment(Environment::sandbox()); // or Environment::production()
+$builder->setFilesEnvironment(Environment::sandbox()); // or Environment::production()
+$api = $builder->build();
+
+$request = new BankAccountFieldQuery();
+$request->payment_network = PaymentNetwork::$local;
+$request->account_holder_type = AccountHolderType::$individual;
+
+try {
+    $response = $api->getInstrumentsClient()->getBankAccountFieldFormatting(Country::$GB, Currency::$GBP, $request);
+} catch (CheckoutApiException $e) {
+    // API error
+    $request_id = $e->request_id;
+    $http_status_code = $e->http_status_code;
+    $error_details = $e->error_details;
+} catch (CheckoutArgumentException $e) {
+    // Bad arguments
+} catch (CheckoutAuthorizationException $e) {
+    // Bad Invalid authorization
+}


### PR DESCRIPTION
This commit adds and replaces existing PHP code samples to match the SDK >2.0.0 usage.

# Description of changes in PR

[//]: # 'Please add your description here'

## Checklist

- [x] Added a changelog entry on the `swagger.yaml` file
- [ N/A] Contacted the Tech Docs team about any corresponding guides that need to be updated for www.checkout.com/docs

**Contributing options**: Look at [our documentation](https://checkout.atlassian.net/wiki/spaces/PD/pages/2169506663/API+ref+publication+process) for options to contribute to the API reference.
