### PR TITLE
Removing ca_public from required list in DsPublicKeys

### DIFF
--- a/nas_spec/components/schemas/Sessions/DsPublicKeys.yaml
+++ b/nas_spec/components/schemas/Sessions/DsPublicKeys.yaml
@@ -2,7 +2,6 @@ type: object
 description: Public certificates specific to a Directory Server (DS) for encrypting device data and verifying ACS signed content. Required when channel is `app`.
 required:
   - ds_public
-  - ca_public
 properties:
   ds_public:
     type: string


### PR DESCRIPTION
# Description of changes in PR

Removing ca_public from required list in DsPublicKeys

## Checklist

- [ ] Added a changelog entry to the `changelog.md` file in either `abc_spec` or `nas_spec`
- [ ] Contacted the Tech Docs team about any corresponding guides that need to be updated for www.checkout.com/docs

**Contributing options**: Look at [our documentation](https://checkout.atlassian.net/wiki/spaces/PD/pages/2169506663/API+ref+publication+process) for options to contribute to the API reference.
