### PR TITLE
Fixed invalid format for `authentication_date`

### DIFF
--- a/nas_spec/changelog.md
+++ b/nas_spec/changelog.md
@@ -2,6 +2,7 @@
 
 | Date       | Description of change                                                                                                 |
 | ---------- | --------------------------------------------------------------------------------------------------------------------- |
+| 2022/03/22 | Fixed invalid format for `authentication_date` |
 | 2022/03/18 | Added Cartes Bancaires changes to Sessions request and response.                                                      |
 | 2022/03/16 | Adds `document` object to the `company` object in the Marketplace API                                                 |
 | 2022/03/09 | Added the `provider_token` payment request source type.                                                               |

--- a/nas_spec/components/schemas/Sessions/CreateSessionAcceptedResponse.yaml
+++ b/nas_spec/components/schemas/Sessions/CreateSessionAcceptedResponse.yaml
@@ -55,7 +55,7 @@ properties:
     $ref: '#/components/schemas/CreateSessionLinks'
   authentication_date:
     type: string
-    format: ISO-8601
+    format: date-time
     description: Authentication date and time
   challenge_indicator:
     type: string

--- a/nas_spec/components/schemas/Sessions/GetSessionResponse.yaml
+++ b/nas_spec/components/schemas/Sessions/GetSessionResponse.yaml
@@ -89,7 +89,7 @@ properties:
     $ref: '#/components/schemas/GetSessionLinks'
   authentication_date:
     type: string
-    format: ISO-8601
+    format: date-time
     description: Authentication date and time
   exemption:
     type: object


### PR DESCRIPTION
# Description of changes in PR

Fixed invalid date format for `authentication-date`

## Checklist

- [x] Added a changelog entry to the `changelog.md` file in either `abc_spec` or `nas_spec`
- [ ] Contacted the Tech Docs team about any corresponding guides that need to be updated for www.checkout.com/docs

**Contributing options**: Look at [our documentation](https://checkout.atlassian.net/wiki/spaces/PD/pages/2169506663/API+ref+publication+process) for options to contribute to the API reference.
