### PR TITLE
Change 'reference' max length from 15 to 50 for Marketplace API

### DIFF
--- a/nas_spec/changelog.md
+++ b/nas_spec/changelog.md
@@ -20,4 +20,4 @@
 | 2021/11/11 | Added `3ds.challenge_indicator` to card payment requests.                                                             |
 | 2021/11/03 | Adds `identification` object under parent `sender` object in payment request.                                         |
 | 2021/10/18 | Added the `marketplaces.sub-entities` object to support split payments.                                               |
-| 2022/03/25 | Increased max length for `reference` in "Onboard a sub-entity" to 15 characters |
+| 2022/03/25 | Increased max length for `reference` in "Onboard a sub-entity" to 50 characters |

--- a/nas_spec/changelog.md
+++ b/nas_spec/changelog.md
@@ -20,3 +20,4 @@
 | 2021/11/11 | Added `3ds.challenge_indicator` to card payment requests.                                                             |
 | 2021/11/03 | Adds `identification` object under parent `sender` object in payment request.                                         |
 | 2021/10/18 | Added the `marketplaces.sub-entities` object to support split payments.                                               |
+| 2022/03/25 | Increased max length for `reference` in "Onboard a sub-entity" to 15 characters |

--- a/nas_spec/components/schemas/Marketplace/EntityCreateRequest.yaml
+++ b/nas_spec/components/schemas/Marketplace/EntityCreateRequest.yaml
@@ -5,7 +5,7 @@ properties:
     type: string
     description: A unique reference you can later use to identify this sub-entity.
     minLength: 1
-    maxLength: 15
+    maxLength: 50
     example: superhero1234
   contact_details:
     title: Contact details


### PR DESCRIPTION
# Description of changes in PR

## Checklist

- [X] Added a changelog entry to the `changelog.md` file in either `abc_spec` or `nas_spec`
- [ ] Contacted the Tech Docs team about any corresponding guides that need to be updated for www.checkout.com/docs

**Contributing options**: Look at [our documentation](https://checkout.atlassian.net/wiki/spaces/PD/pages/2169506663/API+ref+publication+process) for options to contribute to the API reference.
