### PR TITLE
[GTW-7425] Add 3DS2.2 exemptions

### DIFF
--- a/abc_spec/changelog.md
+++ b/abc_spec/changelog.md
@@ -1,7 +1,8 @@
 # Changelog
 
 | Date       | Description of change                                                                                           |
-| ---------- | --------------------------------------------------------------------------------------------------------------- |
+|------------| --------------------------------------------------------------------------------------------------------------- |
+| 2022/06/23 | Added 3ds2.2 exemptions                                                                                         |
 | 2022/05/11 | Added Arabic locale option to Hosted Payments Page and Payment Links.                                           |
 | 2022/05/10 | Added `3ds.challenge_indicator` to Hosted Payments Page and Payment Links.                                      |
 | 2022/04/27 | Added Scandinavian locale options to Hosted Payments Page and Payment Links.                                    |

--- a/abc_spec/components/schemas/Payments/3dsData.yaml
+++ b/abc_spec/components/schemas/Payments/3dsData.yaml
@@ -39,5 +39,31 @@ properties:
     example: '2.1.0'
   exemption:
     type: string
-    description: Specifies an exemption reason so that the payment is not processed using 3D Secure authentication
+    enum:
+      - low_value
+      - secure_corporate_payment
+      - trusted_listing
+      - trusted_listing_prompt
+      - transaction_risk_assessment
+      - 3ds_outage
+      - sca_delegation
+      - out_of_sca_scope
+      - other
+      - low_risk_program
+    description: Specifies an exemption reason so that the payment is not processed using 3D Secure authentication. Learn more about exemptions in our <a href="https://docs.checkout.com/four/payments/regulation-support/sca-compliance-guide#SCAcomplianceguide-PossibleSCAexemptionsexemptions" target="_blank">SCA compliance guide</a>
+    example: 'low_value'
+  exemption_applied:
+    type: string
+    enum:
+      - low_value
+      - secure_corporate_payment
+      - trusted_listing
+      - trusted_listing_prompt
+      - transaction_risk_assessment
+      - 3ds_outage
+      - sca_delegation
+      - out_of_sca_scope
+      - other
+      - low_risk_program
+    description: Specifies the exemption that was applied during authentication so that the payment was not processed using 3D Secure authentication. Learn more about exemptions in our <a href="https://docs.checkout.com/four/payments/regulation-support/sca-compliance-guide#SCAcomplianceguide-PossibleSCAexemptionsexemptions" target="_blank">SCA compliance guide</a>
     example: 'low_value'

--- a/abc_spec/components/schemas/Payments/3dsRequest.yaml
+++ b/abc_spec/components/schemas/Payments/3dsRequest.yaml
@@ -40,7 +40,13 @@ properties:
       - low_value
       - secure_corporate_payment
       - trusted_listing
+      - trusted_listing_prompt
       - transaction_risk_assessment
+      - 3ds_outage
+      - sca_delegation
+      - out_of_sca_scope
+      - other
+      - low_risk_program
     example: 'low_value'
   challenge_indicator:
     type: string

--- a/nas_spec/changelog.md
+++ b/nas_spec/changelog.md
@@ -1,38 +1,39 @@
 # Changelog
 
-| Date       | Description of change                                                                                                |
-|------------|----------------------------------------------------------------------------------------------------------------------|
-| 2022/05/23 | Update Alipay Plus NAS structure                                                                                     |
-| 2022/06/01 | Marketplace API renamed to Accounts API                                                                              |
-| 2022/05/23 | Added Alipay Plus NAS structure                                                                                      |
-| 2022/05/19 | Added WeChat Pay NAS structure                                                                                       |
-| 2022/05/18 | Added "Get transfer details"                                                                                         |
-| 2022/05/11 | Added Arabic locale option to Hosted Payments Page and Payment Links.                                                |
-| 2022/05/10 | Added `3ds.challenge_indicator` to Hosted Payments Page and Payment Links.                                           |
-| 2022/04/28 | Add recurring authentication type in Sessions.                                                                       |
-| 2022/04/27 | Added Scandinavian locale options to Hosted Payments Page and Payment Links.                                         |
-| 2022/04/27 | Added the `challenged` field to the GET payments response schema.                                                    |
-| 2022/04/20 | Added required idempotency key to Transfers API                                                                      |
-| 2022/04/19 | Update `3ds.exemption` available enums                                                                               |
-| 2022/04/06 | Added `/payout-schedules` endpoint with `GET` and `PUT` methods to the Marketplace API                               |
-| 2022/03/30 | Adds "Get action invocations" endpoint                                                                               |
-| 2022/03/28 | Update PHP code samples                                                                                              |
-| 2022/03/25 | Increased max length for `reference` in "Onboard a sub-entity" to 50 characters                                      |
-| 2022/03/22 | Added new scheme `cartes_bancaires` to enum `scheme` in Get and Create Sessions Responses                            |
-| 2022/03/22 | Fixed invalid format for `authentication_date`                                                                       |
-| 2022/03/18 | Added Cartes Bancaires changes to Sessions request and response.                                                     |
-| 2022/03/16 | Adds `document` object to the `company` object in the Marketplace API                                                |
-| 2022/03/09 | Added the `provider_token` payment request source type.                                                              |
-| 2022/03/08 | Change C# samples to suggest the usage of `await` instead of `.Result`                                               |
-| 2022/03/02 | Adds Transfers and Balances                                                                                          |
-| 2022/02/23 | Adds Hosted Payments Page and Payment Links                                                                          |
-| 2022/02/18 | Added `Increment Payment Authorization` code samples for Java & C#                                                   |
-| 2022/02/02 | Adds `active` property for workflows                                                                                 |
-| 2022/01/26 | Update code samples for Java.                                                                                        |
-| 2022/01/25 | Update code samples for C#.                                                                                          |
-| 2022/01/19 | Added test a workflow endpoint.                                                                                      |
-| 2022/01/13 | Update code samples for Node JS.                                                                                     |
+| Date       | Description of change                                                                                                 |
+|------------|-----------------------------------------------------------------------------------------------------------------------|
+| 2022/06/23 | Added 3ds2.2 exemptions                                                                                               |
+| 2022/05/23 | Update Alipay Plus NAS structure                                                                                      |
+| 2022/06/01 | Marketplace API renamed to Accounts API                                                                               |
+| 2022/05/23 | Added Alipay Plus NAS structure                                                                                       |
+| 2022/05/19 | Added WeChat Pay NAS structure                                                                                        |
+| 2022/05/18 | Added "Get transfer details"                                                                                          |
+| 2022/05/11 | Added Arabic locale option to Hosted Payments Page and Payment Links.                                                 |
+| 2022/05/10 | Added `3ds.challenge_indicator` to Hosted Payments Page and Payment Links.                                            |
+| 2022/04/28 | Add recurring authentication type in Sessions.                                                                        |
+| 2022/04/27 | Added Scandinavian locale options to Hosted Payments Page and Payment Links.                                          |
+| 2022/04/27 | Added the `challenged` field to the GET payments response schema.                                                     |
+| 2022/04/20 | Added required idempotency key to Transfers API                                                                       |
+| 2022/04/19 | Update `3ds.exemption` available enums                                                                                |
+| 2022/04/06 | Added `/payout-schedules` endpoint with `GET` and `PUT` methods to the Marketplace API                                |
+| 2022/03/30 | Adds "Get action invocations" endpoint                                                                                |
+| 2022/03/28 | Update PHP code samples                                                                                               |
+| 2022/03/25 | Increased max length for `reference` in "Onboard a sub-entity" to 50 characters                                       |
+| 2022/03/22 | Added new scheme `cartes_bancaires` to enum `scheme` in Get and Create Sessions Responses                             |
+| 2022/03/22 | Fixed invalid format for `authentication_date`                                                                        |
+| 2022/03/18 | Added Cartes Bancaires changes to Sessions request and response.                                                      |
+| 2022/03/16 | Adds `document` object to the `company` object in the Marketplace API                                                 |
+| 2022/03/09 | Added the `provider_token` payment request source type.                                                               |
+| 2022/03/08 | Change C# samples to suggest the usage of `await` instead of `.Result`                                                |
+| 2022/03/02 | Adds Transfers and Balances                                                                                           |
+| 2022/02/23 | Adds Hosted Payments Page and Payment Links                                                                           |
+| 2022/02/18 | Added `Increment Payment Authorization` code samples for Java & C#                                                    |
+| 2022/02/02 | Adds `active` property for workflows                                                                                  |
+| 2022/01/26 | Update code samples for Java.                                                                                         |
+| 2022/01/25 | Update code samples for C#.                                                                                           |
+| 2022/01/19 | Added test a workflow endpoint.                                                                                       |
+| 2022/01/13 | Update code samples for Node JS.                                                                                      |
 | 2021/11/29 | Increase max length of the NAS `success_url` and `failure_url` fields of the payment request (both from 255 to 1024). |
-| 2021/11/11 | Added `3ds.challenge_indicator` to card payment requests.                                                            |
-| 2021/11/03 | Adds `identification` object under parent `sender` object in payment request.                                        |
-| 2021/10/18 | Added the `marketplaces.sub-entities` object to support split payments.                                              |
+| 2021/11/11 | Added `3ds.challenge_indicator` to card payment requests.                                                             |
+| 2021/11/03 | Adds `identification` object under parent `sender` object in payment request.                                         |
+| 2021/10/18 | Added the `marketplaces.sub-entities` object to support split payments.                                               |

--- a/nas_spec/components/schemas/Payments/3dsData.yaml
+++ b/nas_spec/components/schemas/Payments/3dsData.yaml
@@ -43,6 +43,7 @@ properties:
       - low_value
       - secure_corporate_payment
       - trusted_listing
+      - trusted_listing_prompt
       - transaction_risk_assessment
       - 3ds_outage
       - sca_delegation
@@ -50,6 +51,21 @@ properties:
       - other
       - low_risk_program
     description: Specifies an exemption reason so that the payment is not processed using 3D Secure authentication. Learn more about exemptions in our <a href="https://docs.checkout.com/four/payments/regulation-support/sca-compliance-guide#SCAcomplianceguide-PossibleSCAexemptionsexemptions" target="_blank">SCA compliance guide</a>
+    example: 'low_value'
+  exemption_aplied:
+    type: string
+    enum:
+      - low_value
+      - secure_corporate_payment
+      - trusted_listing
+      - trusted_listing_prompt
+      - transaction_risk_assessment
+      - 3ds_outage
+      - sca_delegation
+      - out_of_sca_scope
+      - other
+      - low_risk_program
+    description: Specifies the exemption that was applied during authentication so that the payment was not processed using 3D Secure authentication. Learn more about exemptions in our <a href="https://docs.checkout.com/four/payments/regulation-support/sca-compliance-guide#SCAcomplianceguide-PossibleSCAexemptionsexemptions" target="_blank">SCA compliance guide</a>
     example: 'low_value'
   challenged:
     type: boolean

--- a/nas_spec/components/schemas/Payments/3dsRequest.yaml
+++ b/nas_spec/components/schemas/Payments/3dsRequest.yaml
@@ -39,6 +39,7 @@ properties:
       - low_value
       - secure_corporate_payment
       - trusted_listing
+      - trusted_listing_prompt
       - transaction_risk_assessment
       - 3ds_outage
       - sca_delegation


### PR DESCRIPTION
# Description of changes in PR

[//]: # 'Adding support for 3DS2.2 exemptions on ABC and NAS'

## Checklist

- [x] Added a changelog entry to the `changelog.md` file in either `abc_spec` or `nas_spec`
- [ ] Contacted the Tech Docs team about any corresponding guides that need to be updated for www.checkout.com/docs
(this will be done by @Jason Dantzer

**Contributing options**: Look at [our documentation](https://checkout.atlassian.net/wiki/spaces/PD/pages/2169506663/API+ref+publication+process) for options to contribute to the API reference.
