### PR TITLE
Add missing operation IDs

### DIFF
--- a/nas_spec/paths/_platforms-files.yaml
+++ b/nas_spec/paths/_platforms-files.yaml
@@ -10,6 +10,7 @@ post:
     - url: https://files.sandbox.checkout.com/files
       description: Sandbox server
   summary: Upload a file
+  operationId: uploadAFile
   description: >-
     Our Platforms solution provides an easy way to upload identity documentation required for full due diligence. Please <strong>note</strong> that the sub-domain – https://files.checkout.com – is slightly different to Checkout.com's other endpoints. <br><br>Read the <a href="https://checkout.com/docs/four/platforms/onboarding/api/full/upload-a-file" target="_blank">documentation</a> for more information.
   requestBody:

--- a/nas_spec/paths/accounts@entities.yaml
+++ b/nas_spec/paths/accounts@entities.yaml
@@ -3,6 +3,7 @@ post:
     Onboard a sub-entity so they can start receiving payments. Once created, Checkout.com will run due diligence checks.
     If the checks are successful, we'll enable payment capabilities for that sub-entity and they will start receiving payments.
   summary: Onboard a sub-entity
+  operationId: onboardSubEntity
   requestBody:
     required: true
     description: The sub-entity to be onboarded.

--- a/nas_spec/paths/accounts@entities@{id}.yaml
+++ b/nas_spec/paths/accounts@entities@{id}.yaml
@@ -12,6 +12,7 @@ parameters:
 get:
   description: Use this endpoint to retrieve a sub-entity and its full details.
   summary: Get sub-entity details
+  operationId: getSubEntityDetails
   security:
     - OAuth:
         - accounts

--- a/nas_spec/paths/accounts@entities@{id}@instruments.yaml
+++ b/nas_spec/paths/accounts@entities@{id}@instruments.yaml
@@ -11,6 +11,7 @@ parameters:
 post:
   description: Create a bank account payment instrument for your sub-entity that you can later use as the destination for their payouts.
   summary: Add a payment instrument
+  operationId: addAPaymentInstrument
   requestBody:
     required: true
     description: A JSON payload containing the payment instrument details.

--- a/nas_spec/paths/accounts@entities@{id}@payout-schedules.yaml
+++ b/nas_spec/paths/accounts@entities@{id}@payout-schedules.yaml
@@ -15,6 +15,7 @@ get:
     - OAuth:
         - accounts
   summary: Retrieve a sub-entity's payout schedule
+  operationId: getSubEntitysPayoutSchedule
   description: >-
     You can schedule when your sub-entities receive their funds using our <a href="https://checkout.com/docs/four/platforms" target="_blank">Platforms solution</a>. Use this endpoint to retrieve information about a sub-entity's schedule.
   responses:

--- a/nas_spec/paths/applepay@certificates.yaml
+++ b/nas_spec/paths/applepay@certificates.yaml
@@ -4,6 +4,7 @@ post:
   security:
     - ApiPublicKey: [ ]
   summary: Upload a payment processing certificate
+  operationId: uploadApplePayCertificate
   description: |
     Upload a payment processing certificate. This will allow you to start processing payments via Apple Pay.
   requestBody:

--- a/nas_spec/paths/applepay@signing-requests.yaml
+++ b/nas_spec/paths/applepay@signing-requests.yaml
@@ -4,6 +4,7 @@ post:
   security:
     - ApiPublicKey: [ ]
   summary: Generate a certificate signing request
+  operationId: generateApplePaySigningRequest
   description: |
     Generate a certificate signing request. You'll need to upload this to your Apple Developer account to download a payment processing certificate.
   responses:

--- a/nas_spec/paths/balances@{id}.yaml
+++ b/nas_spec/paths/balances@{id}.yaml
@@ -8,6 +8,7 @@ get:
     - url: https://balances.sandbox.checkout.com
       description: Sandbox server
   summary: Retrieve entity balances
+  operationId: getEntityBalances
   description: Use this endpoint to retrieve balances for each currency account belonging to an entity.
   security:
     - OAuth:

--- a/nas_spec/paths/connect@token.yaml
+++ b/nas_spec/paths/connect@token.yaml
@@ -5,6 +5,7 @@ servers:
     description: Sandbox API
 post:
   summary: Request an access token
+  operationId: requestAnAccessToken
   tags:
     - Access
   responses:

--- a/nas_spec/paths/customers.yaml
+++ b/nas_spec/paths/customers.yaml
@@ -7,6 +7,7 @@ post:
         - vault:customers
     - ApiSecretKey: []
   summary: Create a customer
+  operationId: createCustomer
   description: >
     <a href="https://www.checkout.com/docs/four/payments/store-payment-details/customers" target="_blank">Store a customer's details in a customer object to reuse in future payments</a>. When creating a customer, you can link payment instruments – the customer `id` returned can be passed as a source when making a payment.
     <br/><br>

--- a/nas_spec/paths/customers@{identifier}.yaml
+++ b/nas_spec/paths/customers@{identifier}.yaml
@@ -7,6 +7,7 @@ get:
   tags:
     - Customers
   summary: Get customer details
+  operationId: getCustomerDetails
   description: Returns the details of a customer and their payment instruments.
   parameters:
     - in: path

--- a/nas_spec/paths/disputes.yaml
+++ b/nas_spec/paths/disputes.yaml
@@ -7,6 +7,7 @@ get:
         - disputes:view
     - ApiSecretKey: [ ]
   summary: Get disputes
+  operationId: getDisputes
   description: >-
     Returns a list of all disputes against your business. The results will be
     returned in reverse chronological order, showing the last modified dispute

--- a/nas_spec/paths/disputes@{dispute_id}.yaml
+++ b/nas_spec/paths/disputes@{dispute_id}.yaml
@@ -7,6 +7,7 @@ get:
         - disputes:view
     - ApiSecretKey: [ ]
   summary: Get dispute details
+  operationId: getDisputeDetails
   description: Returns all the details of a dispute using the dispute identifier.
   parameters:
     - in: path

--- a/nas_spec/paths/disputes@{dispute_id}@accept.yaml
+++ b/nas_spec/paths/disputes@{dispute_id}@accept.yaml
@@ -7,6 +7,7 @@ post:
         - disputes:accept
     - ApiSecretKey: [ ]
   summary: Accept dispute
+  operationId: acceptDispute
   description: >-
     If a dispute is legitimate, you can choose to accept it. This will close it
     for you and remove it from your list of open disputes. There are no further

--- a/nas_spec/paths/disputes@{dispute_id}@evidence.yaml
+++ b/nas_spec/paths/disputes@{dispute_id}@evidence.yaml
@@ -7,6 +7,7 @@ put:
         - disputes:provide-evidence
     - ApiSecretKey: [ ]
   summary: Provide dispute evidence
+  operationId: provideDisputeEvidence
   description: >
     Adds supporting evidence to a dispute. Before using this endpoint, you first
     need to [upload your files](#tag/Disputes/paths/~1files/post) using the file

--- a/nas_spec/paths/files.yaml
+++ b/nas_spec/paths/files.yaml
@@ -7,6 +7,7 @@ post:
         - disputes:provide-evidence
     - ApiSecretKey: [ ]
   summary: Upload file
+  operationId: uploadFile
   description: >-
     Upload a file to use as evidence in a dispute. Your file must be in either
     JPEG/JPG, PNG or PDF format, and be no larger than 4MB.

--- a/nas_spec/paths/files@{file_id}.yaml
+++ b/nas_spec/paths/files@{file_id}.yaml
@@ -7,6 +7,7 @@ get:
         - disputes:view
     - ApiSecretKey: [ ]
   summary: Get file information
+  operationId: getFileInformation
   description: Retrieve information about a file that was previously uploaded.
   parameters:
     - in: path

--- a/nas_spec/paths/forex@quotes.yaml
+++ b/nas_spec/paths/forex@quotes.yaml
@@ -5,6 +5,7 @@ post:
     - OAuth:
         - fx
   summary: Request a quote
+  operationId: requestAQuote
   description: |
     Request an exchange rate between a source and destination currency pair that will be used to process one or more payouts. You must submit a payout with the FX quote identifier before the quote expires. If the FX quote identifier is omitted from a payout, and the source and destination currencies differ, the current market exchange rate will be used.
   requestBody:

--- a/nas_spec/paths/instruments.yaml
+++ b/nas_spec/paths/instruments.yaml
@@ -7,6 +7,7 @@ post:
         - vault:instruments
     - ApiSecretKey: [ ]
   summary: Create an instrument
+  operationId: createAnInstrument
   description: |
     Create a card or bank account payment instrument to use for future payments and payouts. <br><br>The parameters you need to provide when creating a bank account payment instrument depend on the account's country and currency. See <a href="https://docs.checkout.com/four/bank-payouts/payout-formatting" target="_blank">our docs</a> and the <a href="#tag/Instruments/paths/~1validation~1bank-accounts~1{country}~1{currency}/get">GET endpoint below</a>.
   requestBody:

--- a/nas_spec/paths/payments@{id}.yaml
+++ b/nas_spec/paths/payments@{id}.yaml
@@ -7,6 +7,7 @@ get:
         - gateway:payment-details
     - ApiSecretKey: [ ]
   summary: Get payment details
+  operationId: getPaymentDetails
   description: |
     Returns the details of the payment with the specified identifier string.
 

--- a/nas_spec/paths/payments@{id}@actions.yaml
+++ b/nas_spec/paths/payments@{id}@actions.yaml
@@ -7,6 +7,7 @@ get:
         - gateway:payment-details
     - ApiSecretKey: [ ]
   summary: Get payment actions
+  operationId: getPaymentActions
   description: |
     Returns all the actions associated with a payment ordered by processing date in descending order (latest first).
   parameters:

--- a/nas_spec/paths/payments@{id}@authorizations.yaml
+++ b/nas_spec/paths/payments@{id}@authorizations.yaml
@@ -7,6 +7,7 @@ post:
         - gateway:payment-authorizations
     - ApiSecretKey: [ ]
   summary: Increment authorization
+  operationId: incrementPaymentAuthorization
   description: |
     Request an incremental authorization to increase the authorization amount or extend the authorization's validity period.
 

--- a/nas_spec/paths/payments@{id}@captures.yaml
+++ b/nas_spec/paths/payments@{id}@captures.yaml
@@ -7,6 +7,7 @@ post:
         - gateway:payment-captures
     - ApiSecretKey: [ ]
   summary: Capture a payment
+  operationId: captureAPayment
   description: |
     Captures a payment if supported by the payment method.
 

--- a/nas_spec/paths/payments@{id}@refunds.yaml
+++ b/nas_spec/paths/payments@{id}@refunds.yaml
@@ -7,6 +7,7 @@ post:
         - gateway:payment-refunds
     - ApiSecretKey: [ ]
   summary: Refund a payment
+  operationId: refundAPayment
   description: |
     Refunds a payment if supported by the payment method.
 

--- a/nas_spec/paths/payments@{id}@voids.yaml
+++ b/nas_spec/paths/payments@{id}@voids.yaml
@@ -7,6 +7,7 @@ post:
         - gateway:payment-voids
     - ApiSecretKey: [ ]
   summary: Void a payment
+  operationId: voidAPayment
   description: |
     Voids a payment if supported by the payment method.
 

--- a/nas_spec/paths/sessions.yaml
+++ b/nas_spec/paths/sessions.yaml
@@ -6,6 +6,7 @@ post:
         - sessions:app
         - sessions:browser
   summary: Request a session
+  operationId: createSession
   description: |
     Create a payment session to authenticate a cardholder before requesting a payment.
     Payment sessions can be linked to one or more payments (in the case of recurring and other merchant-initiated payments).

--- a/nas_spec/paths/sessions@{id}.yaml
+++ b/nas_spec/paths/sessions@{id}.yaml
@@ -7,6 +7,7 @@ get:
         - sessions:browser
     - SessionSecret: [ ]
   summary: Get session details
+  operationId: getSession
   description: |
     Returns the details of the session with the specified identifier string.
   parameters:

--- a/nas_spec/paths/sessions@{id}@collect-data.yaml
+++ b/nas_spec/paths/sessions@{id}@collect-data.yaml
@@ -5,6 +5,7 @@ put:
         - sessions:browser
     - SessionSecret: [ ]
   summary: Update a session
+  operationId: updateSession
   description: Update a session by providing information about the environment.
   tags:
     - Sessions

--- a/nas_spec/paths/sessions@{id}@complete.yaml
+++ b/nas_spec/paths/sessions@{id}@complete.yaml
@@ -5,6 +5,7 @@ post:
         - sessions:browser
     - SessionSecret: [ ]
   summary: Complete a session
+  operationId: completeSession  
   description: |
     Completes a session by posting the the following request to the callback URL (only relevant for non hosted sessions):
     ```

--- a/nas_spec/paths/sessions@{id}@issuer-fingerprint.yaml
+++ b/nas_spec/paths/sessions@{id}@issuer-fingerprint.yaml
@@ -4,6 +4,7 @@ put:
         - sessions:browser
     - SessionSecret: [ ]
   summary: Update session 3DS Method completion indicator
+  operationId: updateSessionThreeDsMethodCompletion
   description: Update the session's 3DS Method completion indicator based on the result of accessing the 3DS Method URL.
   tags:
     - Sessions

--- a/nas_spec/paths/tokens.yaml
+++ b/nas_spec/paths/tokens.yaml
@@ -4,6 +4,7 @@ post:
   security:
     - ApiPublicKey: [ ]
   summary: Request a token
+  operationId: requestAToken
   description: |
     Exchange card details for a reference token that can be used later to request a card payment. Tokens are single use and expire after 15 minutes.
     To create a token, please authenticate using your public key.

--- a/nas_spec/paths/transfers.yaml
+++ b/nas_spec/paths/transfers.yaml
@@ -10,6 +10,7 @@ post:
   description: |
     Initiate a transfer of funds from source entity to destination entity.
   summary: Initiate a transfer of funds
+  operationId: createTransfer
   parameters:
     - $ref: '#/components/parameters/ckoIdempotencyKeyRequired'
   requestBody:

--- a/nas_spec/paths/transfers@{id}.yaml
+++ b/nas_spec/paths/transfers@{id}.yaml
@@ -10,6 +10,7 @@ get:
     - OAuth:
         - transfers:view
   summary: Retrieve a transfer
+  operationId: getTransferDetails
   description: Retrieve transfer details using the transfer identifier.
   parameters:
     - in: path

--- a/nas_spec/paths/validation@bank-accounts@{country}@{currency}.yaml
+++ b/nas_spec/paths/validation@bank-accounts@{country}@{currency}.yaml
@@ -5,6 +5,7 @@ get:
     - OAuth:
         - payouts:bank-details
   summary: Get bank account field formatting
+  operationId: getBankAccountFields
   description: |
     Returns the bank account field formatting required to create bank account instruments or perform payouts for the specified country and currency.
   parameters:


### PR DESCRIPTION
# Description of changes in PR

Add missing operation IDs into NAS spec. These are used by Edge Gateway to tag requests and provide metrics.

**Contributing options**: Look at [our documentation](https://checkout.atlassian.net/wiki/spaces/PD/pages/2169506663/API+ref+publication+process) for options to contribute to the API reference.
