### PR TITLE
Adds enum values to fast_funds field in payment response card source object

### DIFF
--- a/abc_spec/components/schemas/Payments/ResponseSources/01_PaymentResponseCardSource.yaml
+++ b/abc_spec/components/schemas/Payments/ResponseSources/01_PaymentResponseCardSource.yaml
@@ -93,7 +93,12 @@ allOf:
         example: true
       fast_funds:
         type: string
-        description: The fast funds eligibility of the card. [Read more](https://docs.checkout.com/payment-actions/pay-out-to-a-card)
+        enum:
+          - d
+          - c
+          - dc
+          - u
+        description: The fast funds eligibility of the card, as defined during [card verification](https://www.checkout.com/docs/risk-management/card-verification#Verifying_a_card_for_payouts). For more information, see our [Card Payouts](https://docs.checkout.com/payment-actions/pay-out-to-a-card) documentation.
         example: d
       payment_account_reference:
         type: string


### PR DESCRIPTION
# Description of changes in PR

[//]: # 'Added fast_funds enum values and linked to resource with their definitions.'

**Contributing options**: Look at [our documentation](https://checkout.atlassian.net/wiki/spaces/PD/pages/2169506663/API+ref+publication+process) for options to contribute to the API reference.
