### PR TITLE
Fixing payout schedule PUT and GET examples

### DIFF
--- a/nas_spec/changelog.md
+++ b/nas_spec/changelog.md
@@ -2,6 +2,7 @@
 
 | Date       | Description of change                                                                                                 |
 |------------|-----------------------------------------------------------------------------------------------------------------------|
+| 2022/07/19 | Updated example for Platforms payout schedules from `currency` to `GBP` and `ISO`                                     |
 | 2022/07/19 | Update WeChat Pay NAS structure                                                                                       |
 | 2022/07/14 | Add Sofort NAS Request and Response source.                                                                           |
 | 2022/07/14 | Add `locale` property to Get Payment Link details response                                                            |

--- a/nas_spec/components/schemas/Platforms/GetScheduleResponse.yaml
+++ b/nas_spec/components/schemas/Platforms/GetScheduleResponse.yaml
@@ -1,6 +1,6 @@
 type: object
 properties:
-  currency:
+  GBP:
     description: The three-letter ISO currency code of the account's currency.
     type: object
     format: ISO 4217

--- a/nas_spec/components/schemas/Platforms/UpdateScheduleRequest.yaml
+++ b/nas_spec/components/schemas/Platforms/UpdateScheduleRequest.yaml
@@ -1,6 +1,6 @@
 type: object
 properties:
-  currency:
+  ISO:
     description: The three-letter ISO currency code of the account's currency.
     type: object
     format: ISO 4217


### PR DESCRIPTION
# Description of changes in PR

Updating the request and response examples for Platforms sub-entity schedule settings so that they make more sense to the user. Changed `currency` to `ISO` and `GBP` in the PUT and GET respectively.

## Checklist

- [/] Added a changelog entry to the `changelog.md` file in either `abc_spec` or `nas_spec`
- [/] Contacted the Tech Docs team about any corresponding guides that need to be updated for www.checkout.com/docs

**Contributing options**: Look at [our documentation](https://checkout.atlassian.net/wiki/spaces/PD/pages/2169506663/API+ref+publication+process) for options to contribute to the API reference.
