### PR TITLE
remove payment_type: unscheduled

### DIFF
--- a/abc_spec/components/schemas/Payments/Payment.yaml
+++ b/abc_spec/components/schemas/Payments/Payment.yaml
@@ -45,7 +45,6 @@ properties:
       - Recurring
       - MOTO
       - Installment
-      - Unscheduled
     default: Regular
     example: Recurring
   reference:

--- a/abc_spec/components/schemas/Payments/PaymentRequest.yaml
+++ b/abc_spec/components/schemas/Payments/PaymentRequest.yaml
@@ -27,7 +27,6 @@ properties:
       - Recurring
       - MOTO
       - Installment
-      - Unscheduled
     default: Regular
     example: Recurring
   merchant_initiated:

--- a/nas_spec/components/schemas/Payments/Payment.yaml
+++ b/nas_spec/components/schemas/Payments/Payment.yaml
@@ -45,7 +45,6 @@ properties:
       - Recurring
       - MOTO
       - Installment
-      - Unscheduled
     default: Regular
     example: Recurring
   reference:

--- a/nas_spec/components/schemas/Payments/PaymentDetails.yaml
+++ b/nas_spec/components/schemas/Payments/PaymentDetails.yaml
@@ -45,7 +45,6 @@ properties:
       - Recurring
       - MOTO
       - Installment
-      - Unscheduled
     default: Regular
     example: Recurring
   reference:

--- a/nas_spec/components/schemas/Payments/PaymentRequest.yaml
+++ b/nas_spec/components/schemas/Payments/PaymentRequest.yaml
@@ -27,7 +27,6 @@ properties:
       - Recurring
       - MOTO
       - Installment
-      - Unscheduled
     default: Regular
     example: Recurring
   merchant_initiated:


### PR DESCRIPTION
# Description of changes in PR

Removing payment:type: Unscheduled from both MBC and NAS
The feature is ready to be used in prod, but changes in CP SDK are pending


## Checklist


**Contributing options**: Look at [our documentation](https://checkout.atlassian.net/wiki/spaces/PD/pages/2169506663/API+ref+publication+process) for options to contribute to the API reference.
