### PR TITLE
Amend ABC PaymentRequest.processing object to include senderInformation property

### DIFF
--- a/abc_spec/changelog.md
+++ b/abc_spec/changelog.md
@@ -2,6 +2,7 @@
 
 | Date       | Description of change                                                                                           |
 | ---------- | --------------------------------------------------------------------------------------------------------------- |
+| 2022/09/08 | Update PaymentRequest `processing` object to add `senderInformation` property                                   |
 | 2022/08/11 | Update Klarna Payment Request &  Response source.                                                               |
 | 2022/08/03 | Add missing `token_format` to Google Pay and Apple Pay token responses.                                         |
 | 2022/08/01 | Deprecated `baloto` payment method                                                                              |

--- a/abc_spec/components/schemas/Payments/PaymentRequest.yaml
+++ b/abc_spec/components/schemas/Payments/PaymentRequest.yaml
@@ -142,6 +142,12 @@ properties:
             type: string
             description: The last name.
             maxLength: 15
+          dob:
+            type: string
+            format: date
+            description: The recipient's date of birth (yyyy-mm-dd)
+            maxLength: 10
+            example: '1985-05-15'
           address:
             type: string
             description: The address.

--- a/abc_spec/components/schemas/Payments/PaymentRequest.yaml
+++ b/abc_spec/components/schemas/Payments/PaymentRequest.yaml
@@ -126,6 +126,75 @@ properties:
       aft:
         type: boolean
         description: Indicates whether the payment is an [Account Funding Transaction](https://www.checkout.com/docs/previous/payments/manage-payments/account-funding-transactions)
+      senderInformation:
+        type: object
+        description: Allows you to send additional data required for Visa Direct Original Credit Transaction (OCT) and Mastercard Moneysend payments. Only required when sending transactions on behalf of another person or business. <a href="https://www.checkout.com/docs/previous/card-payouts/sender-data-for-card-payouts" target="_blank">See our documentation for specific requirements</a>.
+        properties:
+          reference:
+            type: string
+            description: Merchant's unique customer ID.<br> <i>Alphanumeric characters only</i>.
+            maxLength: 16
+          firstName:
+            type: string
+            description: The first name.
+            maxLength: 15
+          lastName:
+            type: string
+            description: The last name.
+            maxLength: 15
+          address:
+            type: string
+            description: The address.
+            maxLength: 35
+          city:
+            type: string
+            description: The address city.
+            maxLength: 25
+          state:
+            type: string
+            description: The state or province of the address country (<a href="https://en.wikipedia.org/wiki/ISO_3166-2" target="_blank">ISO 3166-2 code</a> of up to three alphanumeric characters).
+            maxLength: 3
+          country:
+            type: string
+            description: The address country (two-letter <a href="https://www.checkout.com/docs/previous/resources/codes/country-codes" target="_blank">ISO country code</a>).
+            maxLength: 2
+          postalCode:
+            type: string
+            description: The post/zip code.<br><i>Only required for Mastercard transactions</i>.
+            maxLength: 10
+          sourceOfFunds:
+            type: string
+            description: The source of the funds.
+            enum:
+              - Credit
+              - Debit
+              - Prepaid
+              - DepositAccount
+              - MobileMoneyAccount
+              - Cash
+          purpose:
+            type: string
+            description: Contains the purpose of the transaction. Required when the destination country is Argentina, Bangladesh, Egypt or India. Mandatory from 15th October 2021.
+            enum:
+              - donations
+              - education
+              - emergency_need
+              - expatriation
+              - family_support
+              - financial_services
+              - gifts
+              - income
+              - insurance
+              - investment
+              - it_services
+              - leisure
+              - loan_payment
+              - medical_treatment
+              - other
+              - pension
+              - royalties
+              - savings
+              - travel_and_tourism
       merchant_initiated_reason:
         type: string
         enum:

--- a/abc_spec/components/schemas/Payments/PaymentRequest.yaml
+++ b/abc_spec/components/schemas/Payments/PaymentRequest.yaml
@@ -128,7 +128,7 @@ properties:
         description: Indicates whether the payment is an [Account Funding Transaction](https://www.checkout.com/docs/previous/payments/manage-payments/account-funding-transactions)
       senderInformation:
         type: object
-        description: Allows you to send additional data required for Visa Direct Original Credit Transaction (OCT) and Mastercard Moneysend payments. Only required when sending transactions on behalf of another person or business. <a href="https://www.checkout.com/docs/previous/card-payouts/sender-data-for-card-payouts" target="_blank">See our documentation for specific requirements</a>.
+        description: Details about the sender. <a href="https://www.checkout.com/docs/previous/payments/manage-payments/account-funding-transactions#Endpoints" target="_blank">See our documentation for specific requirements</a>.
         properties:
           reference:
             type: string


### PR DESCRIPTION
# Description of changes in PR

Updated the abc_spec so that `PaymentRequest.processing` now includes a `senderInformation` property which includes
reference, firstName, lastName, address, city, state, country, postalCode, sourceOfFunds, purpose

## Checklist

- [x] Added a changelog entry to the `changelog.md` file in either `abc_spec` or `nas_spec`
- [ ] Contacted the Tech Docs team about any corresponding guides that need to be updated for www.checkout.com/docs

**Contributing options**: Look at [our documentation](https://checkout.atlassian.net/wiki/spaces/PD/pages/2169506663/API+ref+publication+process) for options to contribute to the API reference.
