### PR TITLE
Fix senderInformation typo and add ISO <=2 char validation

### DIFF
--- a/abc_spec/changelog.md
+++ b/abc_spec/changelog.md
@@ -1,27 +1,28 @@
 # Changelog
 
-| Date       | Description of change                                                                                           |
-| ---------- | --------------------------------------------------------------------------------------------------------------- |
-| 2022/09/08 | Update PaymentRequest `processing` object to add `senderInformation` property                                   |
-| 2022/08/11 | Update Klarna Payment Request &  Response source.                                                               |
-| 2022/08/03 | Add missing `token_format` to Google Pay and Apple Pay token responses.                                         |
-| 2022/08/01 | Deprecated `baloto` payment method                                                                              |
-| 2022/07/29 | Update Java, C#, PHP & Python code samples to match new SDK Version.                                            |
-| 2022/07/14 | Add `locale` property to Get Payment Link details response                                                      |
-| 2022/05/11 | Added Arabic locale option to Hosted Payments Page and Payment Links.                                           |
-| 2022/05/10 | Added `3ds.challenge_indicator` to Hosted Payments Page and Payment Links.                                      |
-| 2022/04/27 | Added Scandinavian locale options to Hosted Payments Page and Payment Links.                                    |
-| 2022/03/30 | Adds new locale options to Hosted Payments Page and Payment Links.                                              |
-| 2022/03/28 | Update PHP code samples                                                                                         |
-| 2022/03/08 | Change C# samples to suggest the usage of `await` instead of `.Result`                                          |
-| 2022/02/23 | Added `allow_payment_methods` to Payment Links and Hosted Payments Page.                                        |
-| 2022/02/18 | Improved and added missing reporting code samples for Java & C#                                                 |
-| 2022/01/26 | Update code samples for Java.                                                                                   |
-| 2022/01/25 | Update code samples for C#.                                                                                     |
-| 2022/01/13 | Update code samples for Node JS.                                                                                |
-| 2021/12/17 | Added `payment_type`, `payment_ip` and `billing_descriptor` to Hosted Payments and Payment Links Get endpoints. |
-| 2021/12/14 | Removed upper limit for `products.price`                                                                        |
-| 2021/11/19 | Added specification for "Get Hosted Payments Page details" endpoint.                                            |
-| 2021/11/11 | Added `3ds.challenge_indicator` to card payment requests.                                                       |
-| 2021/10/18 | Added `processing.purpose` to card payouts.                                                                     |
-| 2021/10/18 | Added `recommendation_code` to payment response.                                                                |
+| Date       | Description of change                                                                                                                      |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| 2022/09/12 | Amended paymentrequest/payout sender state field to have validation of <= 2 chars rather than <= 3 and fixed text description to match.    |
+| 2022/09/08 | Update PaymentRequest `processing` object to add `senderInformation` property                                                              |
+| 2022/08/11 | Update Klarna Payment Request &  Response source.                                                                                          |
+| 2022/08/03 | Add missing `token_format` to Google Pay and Apple Pay token responses.                                                                    |
+| 2022/08/01 | Deprecated `baloto` payment method                                                                                                         |
+| 2022/07/29 | Update Java, C#, PHP & Python code samples to match new SDK Version.                                                                       |
+| 2022/07/14 | Add `locale` property to Get Payment Link details response                                                                                 |
+| 2022/05/11 | Added Arabic locale option to Hosted Payments Page and Payment Links.                                                                      |
+| 2022/05/10 | Added `3ds.challenge_indicator` to Hosted Payments Page and Payment Links.                                                                 |
+| 2022/04/27 | Added Scandinavian locale options to Hosted Payments Page and Payment Links.                                                               |
+| 2022/03/30 | Adds new locale options to Hosted Payments Page and Payment Links.                                                                         |
+| 2022/03/28 | Update PHP code samples                                                                                                                    |
+| 2022/03/08 | Change C# samples to suggest the usage of `await` instead of `.Result`                                                                     |
+| 2022/02/23 | Added `allow_payment_methods` to Payment Links and Hosted Payments Page.                                                                   |
+| 2022/02/18 | Improved and added missing reporting code samples for Java & C#                                                                            |
+| 2022/01/26 | Update code samples for Java.                                                                                                              |
+| 2022/01/25 | Update code samples for C#.                                                                                                                |
+| 2022/01/13 | Update code samples for Node JS.                                                                                                           |
+| 2021/12/17 | Added `payment_type`, `payment_ip` and `billing_descriptor` to Hosted Payments and Payment Links Get endpoints.                            |
+| 2021/12/14 | Removed upper limit for `products.price`                                                                                                   |
+| 2021/11/19 | Added specification for "Get Hosted Payments Page details" endpoint.                                                                       |
+| 2021/11/11 | Added `3ds.challenge_indicator` to card payment requests.                                                                                  |
+| 2021/10/18 | Added `processing.purpose` to card payouts.                                                                                                |
+| 2021/10/18 | Added `recommendation_code` to payment response.                                                                                           |

--- a/abc_spec/components/schemas/Payments/PaymentRequest.yaml
+++ b/abc_spec/components/schemas/Payments/PaymentRequest.yaml
@@ -159,7 +159,6 @@ properties:
           state:
             type: string
             description: The state or province of the address country (<a href="https://en.wikipedia.org/wiki/ISO_3166-2" target="_blank">ISO 3166-2 code</a> of up to two alphanumeric characters).
-            minLength: 2
             maxLength: 2
           country:
             type: string

--- a/abc_spec/components/schemas/Payments/PaymentRequest.yaml
+++ b/abc_spec/components/schemas/Payments/PaymentRequest.yaml
@@ -145,7 +145,7 @@ properties:
           dob:
             type: string
             format: date
-            description: The recipient's date of birth (yyyy-mm-dd)
+            description: The sender's date of birth (yyyy-mm-dd)
             maxLength: 10
             example: '1985-05-15'
           address:
@@ -158,8 +158,9 @@ properties:
             maxLength: 25
           state:
             type: string
-            description: The state or province of the address country (<a href="https://en.wikipedia.org/wiki/ISO_3166-2" target="_blank">ISO 3166-2 code</a> of up to three alphanumeric characters).
-            maxLength: 3
+            description: The state or province of the address country (<a href="https://en.wikipedia.org/wiki/ISO_3166-2" target="_blank">ISO 3166-2 code</a> of up to two alphanumeric characters).
+            minLength: 2
+            maxLength: 2
           country:
             type: string
             description: The address country (two-letter <a href="https://www.checkout.com/docs/previous/resources/codes/country-codes" target="_blank">ISO country code</a>).

--- a/abc_spec/components/schemas/Payments/Payout.yaml
+++ b/abc_spec/components/schemas/Payments/Payout.yaml
@@ -162,8 +162,9 @@ properties:
             maxLength: 25
           state:
             type: string
-            description: The state or province of the address country (<a href="https://en.wikipedia.org/wiki/ISO_3166-2" target="_blank">ISO 3166-2 code</a> of up to three alphanumeric characters).
-            maxLength: 3
+            description: The state or province of the address country (<a href="https://en.wikipedia.org/wiki/ISO_3166-2" target="_blank">ISO 3166-2 code</a> of up to two alphanumeric characters).
+            minLength: 2
+            maxLength: 2
           country:
             type: string
             description: The address country (two-letter <a href="https://www.checkout.com/docs/previous/resources/codes/country-codes" target="_blank">ISO country code</a>).

--- a/abc_spec/components/schemas/Payments/Payout.yaml
+++ b/abc_spec/components/schemas/Payments/Payout.yaml
@@ -163,7 +163,6 @@ properties:
           state:
             type: string
             description: The state or province of the address country (<a href="https://en.wikipedia.org/wiki/ISO_3166-2" target="_blank">ISO 3166-2 code</a> of up to two alphanumeric characters).
-            minLength: 2
             maxLength: 2
           country:
             type: string

--- a/nas_spec/changelog.md
+++ b/nas_spec/changelog.md
@@ -2,6 +2,7 @@
 
 | Date       | Description of change                                                                                                 |
 | ---------- | ----------------------------------------------------------------------------------------------------------------------|
+| 2022/09/12 | Amended address state field to have validation of <= 2 chars rather than <= 3 and fixed text description to match.    |
 | 2022/09/06 | ADD missing challenge indicator field.                                                                                |
 | 2022/09/06 | Added the `processing.partner_customer_id` field to ProcessingData.                                                   |
 | 2022/09/05 | ADD Alma NAS Request source.                                                                                          |   

--- a/nas_spec/components/schemas/Address.yaml
+++ b/nas_spec/components/schemas/Address.yaml
@@ -17,7 +17,7 @@ properties:
     example: London
   state:
     type: string
-    description: The state or province of the address country (ISO 3166-2 code of up to two alphanumeric characters).
+    description: The state or province of the address country (<a href="https://en.wikipedia.org/wiki/ISO_3166-2" target="_blank">ISO 3166-2 code</a> of up to three alphanumeric characters).
     example: London
     maxLength: 2
   zip:

--- a/nas_spec/components/schemas/Address.yaml
+++ b/nas_spec/components/schemas/Address.yaml
@@ -17,8 +17,7 @@ properties:
     example: London
   state:
     type: string
-    description: The state or province of the address country (<a href="https://en.wikipedia.org/wiki/ISO_3166-2" target="_blank">ISO 3166-2 code</a> of up to three alphanumeric characters).
-    example: London
+    description: The state or province of the address country (<a href="https://en.wikipedia.org/wiki/ISO_3166-2" target="_blank">ISO 3166-2 code</a> of up to two alphanumeric characters).
     maxLength: 2
   zip:
     type: string

--- a/nas_spec/components/schemas/Address.yaml
+++ b/nas_spec/components/schemas/Address.yaml
@@ -19,6 +19,7 @@ properties:
     type: string
     description: The address state
     example: London
+    maxLength: 2
   zip:
     type: string
     description: The address zip/postal code

--- a/nas_spec/components/schemas/Address.yaml
+++ b/nas_spec/components/schemas/Address.yaml
@@ -17,7 +17,7 @@ properties:
     example: London
   state:
     type: string
-    description: The address state
+    description: The state or province of the address country (ISO 3166-2 code of up to two alphanumeric characters).
     example: London
     maxLength: 2
   zip:

--- a/nas_spec/components/schemas/Payments/RequestSenders/01_PaymentRequestIndividualSender.yaml
+++ b/nas_spec/components/schemas/Payments/RequestSenders/01_PaymentRequestIndividualSender.yaml
@@ -22,7 +22,7 @@ properties:
   dob:
     type: string
     format: date
-    description: The recipient's date of birth (yyyy-mm-dd)
+    description: The sender's date of birth (yyyy-mm-dd)
     maxLength: 10
     example: '1985-05-15'
   address:

--- a/nas_spec/components/schemas/Payments/RequestSenders/01_PaymentRequestIndividualSender.yaml
+++ b/nas_spec/components/schemas/Payments/RequestSenders/01_PaymentRequestIndividualSender.yaml
@@ -19,6 +19,12 @@ properties:
     type: string
     description: The sender's last name
     example: 'Jones'
+  dob:
+    type: string
+    format: date
+    description: The recipient's date of birth (yyyy-mm-dd)
+    maxLength: 10
+    example: '1985-05-15'
   address:
     description: The sender's address
     allOf:

--- a/nas_spec/components/schemas/Payments/ResponseSenders/01_PaymentResponseIndividualSender.yaml
+++ b/nas_spec/components/schemas/Payments/ResponseSenders/01_PaymentResponseIndividualSender.yaml
@@ -19,12 +19,6 @@ properties:
     type: string
     description: The sender's last name
     example: 'Jones'
-  dob:
-    type: string
-    format: date
-    description: The recipient's date of birth (yyyy-mm-dd)
-    maxLength: 10
-    example: '1985-05-15'
   address:
     description: The sender's address
     allOf:

--- a/nas_spec/components/schemas/Payments/ResponseSenders/01_PaymentResponseIndividualSender.yaml
+++ b/nas_spec/components/schemas/Payments/ResponseSenders/01_PaymentResponseIndividualSender.yaml
@@ -19,6 +19,12 @@ properties:
     type: string
     description: The sender's last name
     example: 'Jones'
+  dob:
+    type: string
+    format: date
+    description: The recipient's date of birth (yyyy-mm-dd)
+    maxLength: 10
+    example: '1985-05-15'
   address:
     description: The sender's address
     allOf:


### PR DESCRIPTION
# Description of changes in PR
- Fixed a typo on ABC `paymentrequest.processing.senderinformation.dob` to say 'sender's dob' rather than 'recipient's dob'
- Amended NAS and ABC `address.state` fields to say <=2 chars rather than <=3 and fix the descriptions to say two chars rather than 3 chars
- Added recipient DOB on NAS recipients

[//]: # 'Please add your description here'

## Checklist

- [x] Added a changelog entry to the `changelog.md` file in either `abc_spec` or `nas_spec`
- [x] Contacted the Tech Docs team about any corresponding guides that need to be updated for www.checkout.com/docs

**Contributing options**: Look at [our documentation](https://checkout.atlassian.net/wiki/spaces/PD/pages/2169506663/API+ref+publication+process) for options to contribute to the API reference.
