### PR TITLE
MP-2976: Add new Integrated Platforms payment instrument endpoints to Platforms docs

### DIFF
--- a/nas_spec/components/schemas/Platforms/EntityCompany.yaml
+++ b/nas_spec/components/schemas/Platforms/EntityCompany.yaml
@@ -43,7 +43,8 @@ properties:
     allOf:
       - $ref: '#/components/schemas/EntityAddress'
   document:
-    - $ref: '#/components/schemas/EntityDocumentCompany'
+    allOf:
+      - $ref: '#/components/schemas/EntityDocumentCompany'
   representatives:
     type: array
     title: Representatives

--- a/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsInstrumentDetailsFasterPayments.yaml
+++ b/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsInstrumentDetailsFasterPayments.yaml
@@ -3,11 +3,11 @@ title: InstrumentDetailsFasterPayments
 properties:
   account_number:
     title: Account number
-    description: Number (which can contain letters) that identifies the account.
+    description: The alphanumeric value that identifies the account
     type: string
     example: '13654567455'
   bank_code:
     title: Bank code
-    description: Code that identifies the bank.
+    description: The code that identifies the bank
     type: string
     example: '123-456'

--- a/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsInstrumentDetailsFasterPayments.yaml
+++ b/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsInstrumentDetailsFasterPayments.yaml
@@ -1,0 +1,13 @@
+type: object
+title: InstrumentDetailsFasterPayments
+properties:
+  account_number:
+    title: Account number
+    description: Number (which can contain letters) that identifies the account.
+    type: string
+    example: '13654567455'
+  bank_code:
+    title: Bank code
+    description: Code that identifies the bank.
+    type: string
+    example: '123-456'

--- a/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsInstrumentDetailsSepa.yaml
+++ b/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsInstrumentDetailsSepa.yaml
@@ -1,0 +1,16 @@
+type: object
+title: InstrumentDetailsSepa
+properties:
+  iban:
+    title: IBAN
+    description: Internationally agreed standard for identifying bank account.
+    type: string
+    minLength: 5
+    maxLength: 34
+    example: 'HU93116000060000000012345676'
+  swift_bic:
+    title: SwiftBic
+    description: An 8 or 11 character code that identifies the bank or bank branch.
+    type: string
+    format: ISO 9362:2009
+    example: '37040044'

--- a/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsInstrumentDetailsSepa.yaml
+++ b/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsInstrumentDetailsSepa.yaml
@@ -3,14 +3,14 @@ title: InstrumentDetailsSepa
 properties:
   iban:
     title: IBAN
-    description: Internationally agreed standard for identifying bank account.
+    description: The account's International Bank Account Number (IBAN)
     type: string
     minLength: 5
     maxLength: 34
     example: 'HU93116000060000000012345676'
   swift_bic:
     title: SwiftBic
-    description: An 8 or 11 character code that identifies the bank or bank branch.
+    description: An 8 or 11 character code that identifies the bank or bank branch
     type: string
     format: ISO 9362:2009
     example: '37040044'

--- a/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrument.yaml
+++ b/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrument.yaml
@@ -3,20 +3,20 @@ title: PaymentInstrumentBase
 properties:
   label:
     title: Label
-    description: A reference you can later use to identify this payment instrument.
+    description: A reference that you can use to identify the payment instrument
     type: string
     minLength: 1
     maxLength: 50
     example: Peter's Personal Account
   type:
     title: Type
-    description: The type of instrument.
+    description: The instrument type
     type: string
     enum:
       - bank_account
   currency:
     title: Currency
-    description: The three-letter ISO currency code of the account's currency.
+    description: The account's currency, as a 3-letter ISO currency code
     type: string
     format: ISO 4217
     minLength: 3
@@ -24,11 +24,11 @@ properties:
     example: 'GBP'
   country:
     title: Country
-    description: The two-letter ISO country code of where the account is based.
+    description: The account's country, as a 2-letter ISO country code
     type: string
     format: ISO 3166-1
     example: 'GB'
   default:
     title: Default
     type: boolean
-    description: Whether the payment instrument should be used as the default payment instrument for payouts.
+    description: Specifies whether the payment instrument should be set as the default payout destination

--- a/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrument.yaml
+++ b/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrument.yaml
@@ -1,0 +1,34 @@
+type: object
+title: PaymentInstrumentBase
+properties:
+  label:
+    title: Label
+    description: A reference you can later use to identify this payment instrument.
+    type: string
+    minLength: 1
+    maxLength: 50
+    example: Peter's Personal Account
+  type:
+    title: Type
+    description: The type of instrument.
+    type: string
+    enum:
+      - bank_account
+  currency:
+    title: Currency
+    description: The three-letter ISO currency code of the account's currency.
+    type: string
+    format: ISO 4217
+    minLength: 3
+    maxLength: 3
+    example: 'GBP'
+  country:
+    title: Country
+    description: The two-letter ISO country code of where the account is based.
+    type: string
+    format: ISO 3166-1
+    example: 'GB'
+  default:
+    title: Default
+    type: boolean
+    description: Whether the payment instrument should be used as the default payment instrument for payouts.

--- a/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentCreate.yaml
+++ b/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentCreate.yaml
@@ -1,0 +1,35 @@
+type: object
+title: PaymentInstrumentCreateRequest
+allOf:
+  - $ref: '#/components/schemas/PlatformsPaymentInstrument'
+  - type: object
+    properties:
+      instrument_details:
+        description: Details of the payment instrument being created. The information required is dependent on the details of the instrument being created.
+        oneOf:
+          - $ref: '#/components/schemas/PlatformsInstrumentDetailsFasterPayments'
+          - $ref: '#/components/schemas/PlatformsInstrumentDetailsSepa'
+        document:
+          type: object
+          title: Document
+          description: A legal document used to verify the bank account.
+          properties:
+            type:
+              type: string
+              description: The type of document.
+              enum:
+                - bank_statement
+              default: bank_statement
+              example: bank_statement
+            file_id:
+              type: string
+              description: The ID of the file representing the uploaded document. The uploaded document must have been uploaded with a purpose of "bank_verification".
+              example: file_wxglze3wwywujg4nna5fb7ldli
+        
+required:
+  - label
+  - type
+  - country
+  - currency
+  - instrument_details
+  - document

--- a/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentCreate.yaml
+++ b/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentCreate.yaml
@@ -12,18 +12,18 @@ allOf:
         document:
           type: object
           title: Document
-          description: A legal document used to verify the bank account.
+          description: A legal document used to verify the bank account
           properties:
             type:
               type: string
-              description: The type of document.
+              description: The document type
               enum:
                 - bank_statement
               default: bank_statement
               example: bank_statement
             file_id:
               type: string
-              description: The ID of the file representing the uploaded document. The uploaded document must have been uploaded with a purpose of "bank_verification".
+              description: The file ID of the uploaded document. The document must have been uploaded for the purpose of `"bank_verification"`.
               example: file_wxglze3wwywujg4nna5fb7ldli
         
 required:

--- a/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentCreate.yaml
+++ b/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentCreate.yaml
@@ -5,7 +5,7 @@ allOf:
   - type: object
     properties:
       instrument_details:
-        description: Details of the payment instrument being created. The information required is dependent on the details of the instrument being created.
+        description: Details of the payment instrument being created.
         oneOf:
           - $ref: '#/components/schemas/PlatformsInstrumentDetailsFasterPayments'
           - $ref: '#/components/schemas/PlatformsInstrumentDetailsSepa'

--- a/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentQuery.yaml
+++ b/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentQuery.yaml
@@ -1,0 +1,11 @@
+type: object
+title: PaymentInstrumentQueryResponse
+properties:
+  data:
+    type: array
+    items:
+      $ref: '#/components/schemas/PlatformsPaymentInstrumentRead'
+  _links:
+    type: object
+    additionalProperties:
+      $ref: '#/components/schemas/Link'

--- a/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentRead.yaml
+++ b/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentRead.yaml
@@ -12,7 +12,7 @@ allOf:
       instrument_id:
         type: string
         title: Status
-        description: The Instrument ID for this payment instrument. Only available once the instrument status is `verified`.
+        description: The payment instrument's ID. Only available once the instrument status is `verified`.
         example: src_wmlfc3zyhqzehihu7giusaaawu
   - $ref: '#/components/schemas/PlatformsPaymentInstrument'
   - type: object

--- a/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentRead.yaml
+++ b/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentRead.yaml
@@ -1,0 +1,24 @@
+type: object
+title: PaymentInstrumentReadResponse
+allOf:
+  - type: object
+    properties:
+      id:
+        type: string
+        description: The ID of the sub-entity's payment instrument.
+        example: ppi_qn4nis4k3ykpzzu7cvtuvhqqga
+      status:
+        $ref: '#/components/schemas/PlatformsPaymentInstrumentStatus'
+      instrument_id:
+        type: string
+        title: Status
+        description: The Instrument ID for this payment instrument. Only available once the instrument status is `verified`.
+        example: src_wmlfc3zyhqzehihu7giusaaawu
+  - $ref: '#/components/schemas/PlatformsPaymentInstrument'
+  - type: object
+    properties:
+      _links:
+        type: object
+        additionalProperties:
+          $ref: '#/components/schemas/Link'
+        

--- a/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentStatus.yaml
+++ b/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentStatus.yaml
@@ -1,6 +1,6 @@
 type: string
 title: Status
-description: The status of your sub-entity's payment instrument, which indicates what stage of verification it's at and whether it's able to be used for payouts.
+description: The status of your sub-entity's payment instrument. The status indicates the instrument's stage of verification, and whether it can be used for payouts.
 example: verified
 enum:
   - pending

--- a/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentStatus.yaml
+++ b/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentStatus.yaml
@@ -1,0 +1,8 @@
+type: string
+title: Status
+description: The status of your sub-entity's payment instrument, which indicates what stage of verification it's at and whether it's able to be used for payouts.
+example: verified
+enum:
+  - pending
+  - verified
+  - verification_failed

--- a/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentStatus.yaml
+++ b/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentStatus.yaml
@@ -5,4 +5,4 @@ example: verified
 enum:
   - pending
   - verified
-  - verification_failed
+  - unverified

--- a/nas_spec/paths/accounts@entities@{entityId}@payment-instruments@{id}.yaml
+++ b/nas_spec/paths/accounts@entities@{entityId}@payment-instruments@{id}.yaml
@@ -1,0 +1,59 @@
+parameters:
+  - in: path
+    name: entityId
+    description: The ID of the sub-entity.
+    required: true
+    allowEmptyValue: false
+    example: ent_w4jelhppmfiufdnatam37wrfc4
+    style: simple
+    schema:
+      type: string
+  - in: path
+    name: id
+    description: The ID of the payment instrument.
+    required: true
+    allowEmptyValue: false
+    example: ppi_qn4nis4k3ykpzzu7cvtuvhqqga
+    style: simple
+    schema:
+      type: string
+get:
+  description: Retrieve the details of a specific payment instrument, including the Instrument ID, used for making ad-hoc Payouts to your sub-entities.
+  summary: Get a payment instrument
+  operationId: getPlatformsPaymentInstrument
+
+  security:
+    - OAuth:
+        - accounts
+  responses:
+    '200':
+      description: Payment instrument details
+      headers:
+        Cko-Version:
+          $ref: '#/components/headers/Cko-Version'
+        Cko-Request-Id:
+          $ref: '#/components/headers/Cko-Request-Id'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PlatformsPaymentInstrumentRead'
+          examples:
+            BankAccount:
+              value:
+                id: ppi_qn4nis4k3ykpzzu7cvtuvhqqga
+                label: Bob's Bank Account
+                type: bank_account
+                currency: GBP
+                country: GB
+                document:
+                  type: bank_statement
+                  file_id: file_wxglze3wwywujg4nna5fb7ldli
+                status: 'verified'
+                default: true
+                instrument_id: 'src_pdasnoaxrtoevpyh3opgaxcrti'
+    '400':
+      description: Bad Request
+    '401':
+      description: Unauthorized
+  tags:
+    - Platforms

--- a/nas_spec/paths/accounts@entities@{entityId}@payment-instruments@{id}.yaml
+++ b/nas_spec/paths/accounts@entities@{entityId}@payment-instruments@{id}.yaml
@@ -1,7 +1,7 @@
 parameters:
   - in: path
     name: entityId
-    description: The ID of the sub-entity.
+    description: The sub-entity's ID.
     required: true
     allowEmptyValue: false
     example: ent_w4jelhppmfiufdnatam37wrfc4
@@ -10,7 +10,7 @@ parameters:
       type: string
   - in: path
     name: id
-    description: The ID of the payment instrument.
+    description: The payment instrument's ID.
     required: true
     allowEmptyValue: false
     example: ppi_qn4nis4k3ykpzzu7cvtuvhqqga
@@ -18,7 +18,7 @@ parameters:
     schema:
       type: string
 get:
-  description: Retrieve the details of a specific payment instrument, including the Instrument ID, used for making on-demand Payouts to your sub-entities.
+  description: Retrieve the details of a specific payment instrument used for sub-entity payouts.
   summary: Get payment instrument details
   operationId: getPlatformsPaymentInstrument
 

--- a/nas_spec/paths/accounts@entities@{entityId}@payment-instruments@{id}.yaml
+++ b/nas_spec/paths/accounts@entities@{entityId}@payment-instruments@{id}.yaml
@@ -19,7 +19,7 @@ parameters:
       type: string
 get:
   description: Retrieve the details of a specific payment instrument, including the Instrument ID, used for making on-demand Payouts to your sub-entities.
-  summary: Get a payment instrument
+  summary: Get payment instrument details
   operationId: getPlatformsPaymentInstrument
 
   security:

--- a/nas_spec/paths/accounts@entities@{entityId}@payment-instruments@{id}.yaml
+++ b/nas_spec/paths/accounts@entities@{entityId}@payment-instruments@{id}.yaml
@@ -18,7 +18,7 @@ parameters:
     schema:
       type: string
 get:
-  description: Retrieve the details of a specific payment instrument, including the Instrument ID, used for making ad-hoc Payouts to your sub-entities.
+  description: Retrieve the details of a specific payment instrument, including the Instrument ID, used for making on-demand Payouts to your sub-entities.
   summary: Get a payment instrument
   operationId: getPlatformsPaymentInstrument
 

--- a/nas_spec/paths/accounts@entities@{id}@instruments.yaml
+++ b/nas_spec/paths/accounts@entities@{id}@instruments.yaml
@@ -9,7 +9,8 @@ parameters:
     schema:
       type: string
 post:
-  description: Create a bank account payment instrument for your sub-entity that you can later use as the destination for their payouts.
+  deprecated: true
+  description: Deprecated in favour of the payment instrument operations at `/payment-instruments`, which offer immediate feedback on whether the instrument was created successfully or not. Create a bank account payment instrument for your sub-entity that you can later use as the destination for their payouts.
   summary: Add a payment instrument
   operationId: addAPaymentInstrument
   requestBody:

--- a/nas_spec/paths/accounts@entities@{id}@instruments.yaml
+++ b/nas_spec/paths/accounts@entities@{id}@instruments.yaml
@@ -11,7 +11,8 @@ parameters:
 post:
   deprecated: true
   description: |
-    Use the payment instrument operations at `/payment-instruments` instead. 
+    Use the payment instrument operations at `/payment-instruments` instead.
+    
     Create a bank account payment instrument for your sub-entity that you can later use as the destination for their payouts.
   summary: Add a payment instrument
   operationId: addAPaymentInstrument

--- a/nas_spec/paths/accounts@entities@{id}@instruments.yaml
+++ b/nas_spec/paths/accounts@entities@{id}@instruments.yaml
@@ -10,7 +10,10 @@ parameters:
       type: string
 post:
   deprecated: true
-  description: Deprecated in favour of the payment instrument operations at `/payment-instruments`, which offer immediate feedback on whether the instrument was created successfully or not. Create a bank account payment instrument for your sub-entity that you can later use as the destination for their payouts.
+  description: |
+  Use the payment instrument operations at `/payment-instruments` instead. 
+  
+  Create a bank account payment instrument for your sub-entity that you can later use as the destination for their payouts.
   summary: Add a payment instrument
   operationId: addAPaymentInstrument
   requestBody:

--- a/nas_spec/paths/accounts@entities@{id}@instruments.yaml
+++ b/nas_spec/paths/accounts@entities@{id}@instruments.yaml
@@ -11,9 +11,8 @@ parameters:
 post:
   deprecated: true
   description: |
-  Use the payment instrument operations at `/payment-instruments` instead. 
-  
-  Create a bank account payment instrument for your sub-entity that you can later use as the destination for their payouts.
+    Use the payment instrument operations at `/payment-instruments` instead. 
+    Create a bank account payment instrument for your sub-entity that you can later use as the destination for their payouts.
   summary: Add a payment instrument
   operationId: addAPaymentInstrument
   requestBody:

--- a/nas_spec/paths/accounts@entities@{id}@payment-instruments.yaml
+++ b/nas_spec/paths/accounts@entities@{id}@payment-instruments.yaml
@@ -58,13 +58,11 @@ post:
       content:
         application/json:
           schema:
+            type: object
             properties:
               id:
                 type: string
                 example: ppi_qn4nis4k3ykpzzu7cvtuvhqqga
-          examples:
-            success:
-              id: ppi_qn4nis4k3ykpzzu7cvtuvhqqga
     '400':
       description: Bad Request
     '401':

--- a/nas_spec/paths/accounts@entities@{id}@payment-instruments.yaml
+++ b/nas_spec/paths/accounts@entities@{id}@payment-instruments.yaml
@@ -1,0 +1,140 @@
+parameters:
+  - in: path
+    name: id
+    description: The ID of the sub-entity.
+    required: true
+    allowEmptyValue: false
+    example: ent_w4jelhppmfiufdnatam37wrfc4
+    style: simple
+    schema:
+      type: string
+post:
+  description: Create a bank account payment instrument for your sub-entity that you can later use as the destination for their payouts.
+  summary: Add a payment instrument
+  operationId: addPlatformsPaymentInstrument
+  requestBody:
+    required: true
+    description: A JSON payload containing the payment instrument details.
+    content:
+      application/json:
+        schema:
+          $ref: '#/components/schemas/PlatformsPaymentInstrumentCreate'
+        examples:
+          FasterPaymentsBankAccount:
+            value:
+              label: Bob's Bank Account
+              type: bank_account
+              currency: GBP
+              country: GB
+              instrument_details:
+                account_number: '12345678'
+                bank_code: '050389'
+              document:
+                type: bank_statement
+                file_id: file_wxglze3wwywujg4nna5fb7ldli
+          SepaBankAccount:
+            value:
+              label: Bruno's Bank Account
+              type: bank_account
+              instrument_details:
+                iban: FR1420041010050500013M02606,
+                swift_bic: LZSKFR2E98I
+              currency: EUR
+              country: FR
+              document:
+                type: bank_statement
+                file_id: file_wxglze3wwywujg4nna5fb7ldli
+  security:
+    - OAuth:
+        - accounts
+  responses:
+    '201':
+      description: Created
+      headers:
+        Cko-Version:
+          $ref: '#/components/headers/Cko-Version'
+        Cko-Request-Id:
+          $ref: '#/components/headers/Cko-Request-Id'
+      content:
+        application/json:
+          schema:
+            properties:
+              id:
+                type: string
+                example: ppi_qn4nis4k3ykpzzu7cvtuvhqqga
+          examples:
+            success:
+              id: ppi_qn4nis4k3ykpzzu7cvtuvhqqga
+    '400':
+      description: Bad Request
+    '401':
+      description: Unauthorized
+    '422':
+      description: Invalid data was sent
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: '#/components/schemas/ValidationError'
+              - type: object
+                properties:
+                  error_codes:
+                    example:
+                      - error_code1
+                      - error_code2
+  tags: [ Platforms ]
+
+get:
+  description: Fetch all of the payment instruments for a sub-entity. Can be filtered by `status` to allow easy identification of `verified` instruments that are ready to be used for Payouts.
+  summary: Query payment instruments
+  operationId: queryPlatformsPaymentInstruments
+
+  parameters:
+    - in: query
+      name: status
+      schema:
+        $ref: '#/components/schemas/PlatformsPaymentInstrumentStatus'
+
+
+  security:
+    - OAuth:
+        - accounts
+  responses:
+    '200':
+      description: OK
+      headers:
+        Cko-Version:
+          $ref: '#/components/headers/Cko-Version'
+        Cko-Request-Id:
+          $ref: '#/components/headers/Cko-Request-Id'
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PlatformsPaymentInstrumentQuery'
+          examples:
+            BankAccounts:
+              value:
+                data: 
+                  - id: ppi_qn4nis4k3ykpzzu7cvtuvhqqga
+                    label: Bob's Bank Account
+                    type: bank_account
+                    currency: GBP
+                    country: GB
+                    status: 'verified'
+                    default: true
+                    instrument_id: 'src_pdasnoaxrtoevpyh3opgaxcrti'
+                  - id: ppi_yk7nmh5jypmqzw5kb6kshj2iiy
+                    label: Bruno's Bank Account
+                    type: bank_account
+                    currency: EUR
+                    country: FR
+                    status: 'pending'
+                    default: false
+                
+    '400':
+      description: Bad Request
+    '401':
+      description: Unauthorized
+  tags:
+    - Platforms
+

--- a/nas_spec/paths/accounts@entities@{id}@payment-instruments.yaml
+++ b/nas_spec/paths/accounts@entities@{id}@payment-instruments.yaml
@@ -1,7 +1,7 @@
 parameters:
   - in: path
     name: id
-    description: The ID of the sub-entity.
+    description: The sub-entity's ID.
     required: true
     allowEmptyValue: false
     example: ent_w4jelhppmfiufdnatam37wrfc4
@@ -9,7 +9,7 @@ parameters:
     schema:
       type: string
 post:
-  description: Create a bank account payment instrument for your sub-entity that you can later use as the destination for their payouts.
+  description: Create a bank account payment instrument for your sub-entity. You can use this payment instrument as a payout destination.
   summary: Add a payment instrument
   operationId: addPlatformsPaymentInstrument
   requestBody:
@@ -85,7 +85,7 @@ post:
   tags: [ Platforms ]
 
 get:
-  description: Fetch all of the payment instruments for a sub-entity. Can be filtered by `status` to allow easy identification of `verified` instruments that are ready to be used for Payouts.
+  description: Fetch all of the payment instruments for a sub-entity. You can filter by `status` to identify `verified` instruments that are ready to be used for Payouts.
   summary: Query payment instruments
   operationId: queryPlatformsPaymentInstruments
 


### PR DESCRIPTION
# Description of changes in PR

Integrated Platforms have added a new flow for creating and managing payment instruments for a sub-entity. This new flow is standalone from the existing flow, so there will be no breaking changes. We'll be encouraging merchants with existing integrations to move over ASAP.

Compared to the existing flow, there are two simple read endpoints added, one for getting by ID and one for querying.

There's also a new add endpoint, which offers immediate feedback on instrument creation. The existing flow required merchants to listen to webhooks to find out if their request had suceeded or failed.

I think one of the trickiest things here is trying to distinguish between the Platforms Payment Instrument ID - an identifier we're using to manage the process of onboarding a payment instrument for a sub-entity, and the 'Instrument ID' which is the more typical Vault instrument ID.

## Checklist

- [ ] Added a changelog entry to the `changelog.md` file in either `abc_spec` or `nas_spec`
- [ ] Contacted the Tech Docs team about any corresponding guides that need to be updated for www.checkout.com/docs

**Contributing options**: Look at [our documentation](https://checkout.atlassian.net/wiki/spaces/PD/pages/2169506663/API+ref+publication+process) for options to contribute to the API reference.
