### PR TITLE
AUTH-1723: Removed wrong remark about app on Sessions channel data

### DIFF
--- a/nas_spec/changelog.md
+++ b/nas_spec/changelog.md
@@ -2,6 +2,7 @@
 
 | Date       | Description of change
 | ---------- | ----------------------------------------------------------------------------------------------------------------------|
+| 2022/10/20 | Removed wrong remark about app on Sessions channel data                                                               |
 | 2022/10/20 | Added the `3ds.allow_upgrade` to payment requests & `3ds.upgrade_reason` to the 202 accepted & GET endpoint responses |
 | 2022/10/18 | Add new challenge indicator for authentication: data_share                                                            | 
 | 2022/10/17 | Fixed Card and Token sources in Session to not have store_for_future_use                                              |

--- a/nas_spec/components/schemas/Sessions/ChannelData.yaml
+++ b/nas_spec/components/schemas/Sessions/ChannelData.yaml
@@ -9,8 +9,7 @@ discriminator:
 properties:
   channel:
     type: string
-    description: Indicates the type of channel interface being used to initiate the transaction.</br>
-      If the channel is `app` then `501 Not Implemented` is returned.
+    description: Indicates the type of channel interface being used to initiate the transaction.
     default: 'browser'
 example:
   channel: browser


### PR DESCRIPTION
# Description of changes in PR

[//]: # 'Removed wrong remark about app on Sessions channel data'

## Checklist

- [x] Added a changelog entry to the `changelog.md` file in either `abc_spec` or `nas_spec`
- [ ] Contacted the Tech Docs team about any corresponding guides that need to be updated for www.checkout.com/docs

**Contributing options**: Look at [our documentation](https://checkout.atlassian.net/wiki/spaces/PD/pages/2169506663/API+ref+publication+process) for options to contribute to the API reference.
