### PR TITLE
MP-2976: Fix issue with 'document' property on Platforms Add Instrument request

### DIFF
--- a/nas_spec/changelog.md
+++ b/nas_spec/changelog.md
@@ -2,6 +2,7 @@
 
 | Date       | Description of change                                                                                                 
 | ---------- |-----------------------------------------------------------------------------------------------------------------------|
+| 2022/11/2 | Fix indentation bug causing 'document' property to not be shown in `PlatformsPaymentInstrumentCreate.yaml`                                                           
 | 2022/10/31 | Updated `payment_method` to be mandatory                                                                              |
 | 2022/10/25 | Added Card Metadata API                                                                                               |
 | 2022/10/20 | Removed wrong remark about app on Sessions channel data                                                               |

--- a/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentCreate.yaml
+++ b/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentCreate.yaml
@@ -9,22 +9,22 @@ allOf:
         oneOf:
           - $ref: '#/components/schemas/PlatformsInstrumentDetailsFasterPayments'
           - $ref: '#/components/schemas/PlatformsInstrumentDetailsSepa'
-        document:
-          type: object
-          title: Document
-          description: A legal document used to verify the bank account
-          properties:
-            type:
-              type: string
-              description: The document type
-              enum:
-                - bank_statement
-              default: bank_statement
-              example: bank_statement
-            file_id:
-              type: string
-              description: The file ID of the uploaded document. The document must have been uploaded for the purpose of `"bank_verification"`.
-              example: file_wxglze3wwywujg4nna5fb7ldli
+      document:
+        type: object
+        title: Document
+        description: A legal document used to verify the bank account
+        properties:
+          type:
+            type: string
+            description: The document type
+            enum:
+              - bank_statement
+            default: bank_statement
+            example: bank_statement
+          file_id:
+            type: string
+            description: The file ID of the uploaded document. The document must have been uploaded for the purpose of `"bank_verification"`.
+            example: file_wxglze3wwywujg4nna5fb7ldli
         
 required:
   - label


### PR DESCRIPTION
# Description of changes in PR

Fixes an indentation bug where the `document` field on the 'Add Payment Instrument` request is not shown.

## Checklist

- [x] Added a changelog entry to the `changelog.md` file in either `abc_spec` or `nas_spec`
- [x] Contacted the Tech Docs team about any corresponding guides that need to be updated for www.checkout.com/docs

**Contributing options**: Look at [our documentation](https://checkout.atlassian.net/wiki/spaces/PD/pages/2169506663/API+ref+publication+process) for options to contribute to the API reference.
