### PR TITLE
GTW-8985: Recipient/sender changes in API docs

### DIFF
--- a/nas_spec/changelog.md
+++ b/nas_spec/changelog.md
@@ -2,9 +2,11 @@
 
 | Date       | Description of change                                                                                                 
 |------------|-----------------------------------------------------------------------------------------------------------------------|
+| 2022/11/29 | Added `first_name` and `address` to `recipient`, deprecated `recipient.zip`, made `sender.address` optional.          |
 | 2022/11/29 | Adding prism device_session_id to payment request.                                                                    |
 | 2022/11/15 | Adding a `entity` to BankPayoutRequest source.                                                                        |
 | 2022/11/14 | Changing Card Metadata API request format                                                                             |
+| 2022/11/09 | Removed the `risk` endpoints                                                                                          |
 | 2022/11/03 | Added `score` property to the `risk` object on the 201 created payment response and GET details response              |
 | 2022/11/02 | Fix indentation bug causing 'document' property to not be shown in `PlatformsPaymentInstrumentCreate.yaml`            |   
 | 2022/11/02 | Ensure 'document' property is exposed on all relevant Platforms payment instruments schemas                           |
@@ -100,4 +102,3 @@
 | 2021/11/11 | Added `3ds.challenge_indicator` to card payment requests.                                                             |
 | 2021/11/03 | Adds `identification` object under parent `sender` object in payment request.                                         |
 | 2021/10/18 | Added the `marketplaces.sub-entities` object to support split payments.                                               |
-| 2022/11/09 | Removed the `risk` endpoints                                                                                          |

--- a/nas_spec/components/schemas/Payments/PaymentRecipient.yaml
+++ b/nas_spec/components/schemas/Payments/PaymentRecipient.yaml
@@ -12,12 +12,22 @@ properties:
     description: The first six digits and the last four digits of the primary recipient's card, without spaces, or up to ten digits of the primary recipient's account number
     minLength: 10
     maxLength: 10
-    example: '5555554444'
+    example: '5555554444'  
+  address:
+    description: The recipient's address
+    allOf:
+      - $ref: '#/components/schemas/Address'
   zip:
     type: string
+    deprecated: true
     description: The first part of the UK postcode (e.g., W1T 4TJ would be W1T)
     maxLength: 10
     example: 'W1T'
+  first_name:
+    type: string
+    description: The recipient's first name
+    maxLength: 50
+    example: 'John'
   last_name:
     type: string
     description: The recipient's last name

--- a/nas_spec/components/schemas/Payments/PaymentRecipient.yaml
+++ b/nas_spec/components/schemas/Payments/PaymentRecipient.yaml
@@ -20,7 +20,10 @@ properties:
   zip:
     type: string
     deprecated: true
-    description: The first part of the UK postcode (e.g., W1T 4TJ would be W1T)
+    description: |
+      Replaced by `address.zip`
+  
+      The first part of the UK postcode (e.g., W1T 4TJ would be W1T).
     maxLength: 10
     example: 'W1T'
   first_name:

--- a/nas_spec/components/schemas/Payments/PaymentRequestSender.yaml
+++ b/nas_spec/components/schemas/Payments/PaymentRequestSender.yaml
@@ -8,7 +8,6 @@ discriminator:
     instrument: '#/components/schemas/03_PaymentRequestInstrumentSender'
 required:
   - type
-  - reference
 properties:
   type:
     type: string

--- a/nas_spec/components/schemas/Payments/RequestSenders/01_PaymentRequestIndividualSender.yaml
+++ b/nas_spec/components/schemas/Payments/RequestSenders/01_PaymentRequestIndividualSender.yaml
@@ -6,6 +6,7 @@ required:
   - type
   - first_name
   - last_name
+  - address 
 properties:
   type:
     type: string

--- a/nas_spec/components/schemas/Payments/RequestSenders/01_PaymentRequestIndividualSender.yaml
+++ b/nas_spec/components/schemas/Payments/RequestSenders/01_PaymentRequestIndividualSender.yaml
@@ -6,7 +6,6 @@ required:
   - type
   - first_name
   - last_name
-  - address
 properties:
   type:
     type: string

--- a/nas_spec/components/schemas/Payments/RequestSenders/02_PaymentRequestCorporateSender.yaml
+++ b/nas_spec/components/schemas/Payments/RequestSenders/02_PaymentRequestCorporateSender.yaml
@@ -5,7 +5,6 @@ allOf:
 required:
   - type
   - company_name
-  - address
 properties:
   type:
     type: string

--- a/nas_spec/components/schemas/Payments/RequestSenders/02_PaymentRequestCorporateSender.yaml
+++ b/nas_spec/components/schemas/Payments/RequestSenders/02_PaymentRequestCorporateSender.yaml
@@ -5,6 +5,7 @@ allOf:
 required:
   - type
   - company_name
+  - address 
 properties:
   type:
     type: string


### PR DESCRIPTION
- Mark `recipient.zip` deprecated
- Add the `recipient.address` object  @jason-dantzer-cko I've used the same address object the other places use. Is this okay?
- Add `recipient.first_name`
![image](https://user-images.githubusercontent.com/111371044/205357606-69298421-4f4e-4368-a3e1-07162454cc45.png)

- `sender.address` no longer required
![image](https://user-images.githubusercontent.com/111371044/205357234-df2ca13d-1cf4-4a35-93f7-1123370a1b25.png)



## Checklist

- [x] Added a changelog entry to the `changelog.md` file in either `abc_spec` or `nas_spec`
- [ ] Contacted the Tech Docs team about any corresponding guides that need to be updated for www.checkout.com/docs

**Contributing options**: Look at [our documentation](https://checkout.atlassian.net/wiki/spaces/PD/pages/2169506663/API+ref+publication+process) for options to contribute to the API reference.
