### PR TITLE
Missing available property on Accounts responses

### DIFF
--- a/nas_spec/changelog.md
+++ b/nas_spec/changelog.md
@@ -2,7 +2,8 @@
 
 | Date       | Description of change                                                                                                 
 |------------|-----------------------------------------------------------------------------------------------------------------------|
-| 2022/12/13 | Remove third-party fields from integrated auth                                                                          |
+| 2022/12/14 | Add missing `available` property to Accounts Individual and Company responses                                         |
+| 2022/12/13 | Remove third-party fields from integrated auth                                                                        |
 | 2022/11/30 | Add API key security to IP endpoints.                                                                                 |
 | 2022/11/29 | Adding prism device_session_id to payment request.                                                                    |
 | 2022/11/15 | Adding a `entity` to BankPayoutRequest source.                                                                        |

--- a/nas_spec/paths/accounts@entities@{id}.yaml
+++ b/nas_spec/paths/accounts@entities@{id}.yaml
@@ -32,8 +32,10 @@ get:
                 reference: superhero1234
                 capabilities:
                   payments:
+                    available: true
                     enabled: false
                   payouts:
+                    available: true
                     enabled: false
                 status: pending
                 contact_details:
@@ -109,8 +111,10 @@ get:
                 reference: superhero1234
                 capabilities:
                   payments:
+                    available: true
                     enabled: false
                   payouts:
+                    available: true
                     enabled: false
                 contact_details:
                   phone:


### PR DESCRIPTION
# Description of changes in PR

[//]: # 'Added missing `available` property into the company and individual sub-entity responses'

## Checklist

- [x] Added a changelog entry to the `changelog.md` file in either `abc_spec` or `nas_spec`
- [x] Contacted the Tech Docs team about any corresponding guides that need to be updated for www.checkout.com/docs

**Contributing options**: Look at [our documentation](https://checkout.atlassian.net/wiki/spaces/PD/pages/2169506663/API+ref+publication+process) for options to contribute to the API reference.
