### PR TITLE
Changing by_day schedule examples to be arrays

### DIFF
--- a/nas_spec/changelog.md
+++ b/nas_spec/changelog.md
@@ -2,6 +2,7 @@
 
 | Date       | Description of change                                                                                                 
 |------------|-----------------------------------------------------------------------------------------------------------------------|
+| 2022/12/15 | Change Platforms schedule by_day response samples to use arrays                                                       |
 | 2022/12/15 | Add CV Connect NAS Request and Response source.                                                                       |
 | 2022/12/15 | Add Trustly NAS Request and Response source.                                                                          |
 | 2022/12/15 | Add Illicado NAS Request and Response source.                                                                         |

--- a/nas_spec/changelog.md
+++ b/nas_spec/changelog.md
@@ -2,7 +2,7 @@
 
 | Date       | Description of change                                                                                                 
 |------------|-----------------------------------------------------------------------------------------------------------------------|
-| 2022/12/15 | Change Platforms schedule by_day response samples to use arrays                                                       |
+| 2022/12/15 | Change Platforms schedule `by_day` response samples to use arrays                                                       |
 | 2022/12/15 | Add CV Connect NAS Request and Response source.                                                                       |
 | 2022/12/15 | Add Trustly NAS Request and Response source.                                                                          |
 | 2022/12/15 | Add Illicado NAS Request and Response source.                                                                         |

--- a/nas_spec/components/schemas/Platforms/GetScheduleResponse.yaml
+++ b/nas_spec/components/schemas/Platforms/GetScheduleResponse.yaml
@@ -40,7 +40,7 @@ properties:
                 example: 'weekly'
             example:
               frequency: 'weekly'
-              by_day: 'monday'
+              by_day: ['monday']
       _links:
         additionalProperties:
           $ref: '#/components/schemas/Link'

--- a/nas_spec/components/schemas/Platforms/UpdateScheduleRequest.yaml
+++ b/nas_spec/components/schemas/Platforms/UpdateScheduleRequest.yaml
@@ -31,4 +31,4 @@ properties:
             example: 'weekly'
         example:
           frequency: weekly
-          by_day: monday
+          by_day: [ monday ]


### PR DESCRIPTION
# Description of changes in PR

[//]: # 'Changing the by_day response/request examples to be arrays'

## Checklist

- [x] Added a changelog entry to the `changelog.md` file in either `abc_spec` or `nas_spec`
- [x] Contacted the Tech Docs team about any corresponding guides that need to be updated for www.checkout.com/docs

**Contributing options**: Look at [our documentation](https://checkout.atlassian.net/wiki/spaces/PD/pages/2169506663/API+ref+publication+process) for options to contribute to the API reference.
