### PR TITLE
chore: PX-127 Add Portuguese and Greek locale options to Hosted Payments Page and Payment Links

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,5 +3,5 @@
 /abc_spec/components/schemas/Payments/ @checkout/gateway-product-cko
 /nas_spec/components/schemas/Payments/ @checkout/gateway-product-cko
 
-/nas_spec/components/schemas/PaymentLinks/ @checkout/payment-interfaces-cko
-/nas_spec/components/schemas/HostedPayments/ @checkout/payment-interfaces-cko
+/nas_spec/components/schemas/PaymentLinks/ @checkout/payment-experience-cko
+/nas_spec/components/schemas/HostedPayments/ @checkout/payment-experience-cko

--- a/abc_spec/changelog.md
+++ b/abc_spec/changelog.md
@@ -2,7 +2,8 @@
 
 | Date       | Description of change                                                                                                                   |
 |------------|-----------------------------------------------------------------------------------------------------------------------------------------|
-| 2023/01/24 | Added `WebhookRequestPut` & `WebhookRequestPatch` to distinguish between the required parameters for each request
+| 2023/02/07 | Added Portuguese and Greek locale options to Hosted Payments Page and Payment Links                                                     |
+| 2023/01/24 | Added `WebhookRequestPut` & `WebhookRequestPatch` to distinguish between the required parameters for each request                       |
 | 2023/01/16 | Added `recipient.first_name` to ABC API Spec.                                                                                           |
 | 2022/09/29 | Added new GET Payments endpoint                                                                                                         |                                                             
 | 2022/09/21 | Added the `3ds.allow_upgrade` to payment requests & `3ds.upgrade_reason` to the 202 accepted & GET endpoint responses                   |

--- a/abc_spec/components/schemas/HostedPayments/HostedPaymentsRequest.yaml
+++ b/abc_spec/components/schemas/HostedPayments/HostedPaymentsRequest.yaml
@@ -200,6 +200,7 @@ properties:
       - de-AT
       - de-CH
       - de-DE
+      - el
       - en-AT
       - en-CH
       - en-DE
@@ -222,6 +223,7 @@ properties:
       - ms-MY
       - nb-NO
       - nl-NL
+      - pt-PT
       - sv-SE
       - th-TH
       - vi-VN

--- a/abc_spec/components/schemas/PaymentLinks/GetPaymentLinkResponse.yaml
+++ b/abc_spec/components/schemas/PaymentLinks/GetPaymentLinkResponse.yaml
@@ -147,6 +147,7 @@ properties:
       - de-AT
       - de-CH
       - de-DE
+      - el
       - en-AT
       - en-CH
       - en-DE
@@ -169,6 +170,7 @@ properties:
       - ms-MY
       - nb-NO
       - nl-NL
+      - pt-PT
       - sv-SE
       - th-TH
       - vi-VN

--- a/abc_spec/components/schemas/PaymentLinks/PaymentLinksRequest.yaml
+++ b/abc_spec/components/schemas/PaymentLinks/PaymentLinksRequest.yaml
@@ -214,6 +214,7 @@ properties:
       - de-AT
       - de-CH
       - de-DE
+      - el
       - en-AT
       - en-CH
       - en-DE
@@ -236,6 +237,7 @@ properties:
       - ms-MY
       - nb-NO
       - nl-NL
+      - pt-PT
       - sv-SE
       - th-TH
       - vi-VN

--- a/nas_spec/changelog.md
+++ b/nas_spec/changelog.md
@@ -1,8 +1,9 @@
 # Changelog
 
-| Date       | Description of change                                                                                                 
+| Date       | Description of change                                                                                                 |
 |------------|-----------------------------------------------------------------------------------------------------------------------|
-| 2023/02/01 | Update file uploads/retrievals for Platforms.
+| 2023/02/07 | Added Portuguese and Greek locale options to Hosted Payments Page and Payment Links                                   |
+| 2023/02/01 | Update file uploads/retrievals for Platforms.                                                                         |
 | 2023/02/01 | Added the API reference for the Financial Actions API.                                                                |
 | 2023/01/26 | Add SEPA DD NAS Request and Response sources                                                                          |
 | 2023/01/24 | Update PaymentResponse `processing` object to add `partner_payment_id`, `partner_status`, `partner_transaction_id`,   |

--- a/nas_spec/changelog.md
+++ b/nas_spec/changelog.md
@@ -3,7 +3,7 @@
 | Date       | Description of change                                                                                                 |
 |------------|-----------------------------------------------------------------------------------------------------------------------|
 | 2023/02/07 | Added Portuguese and Greek locale options to Hosted Payments Page and Payment Links                                   |
-| 2023/02/01 | Update file uploads/retrievals for Platforms.                                                                         |
+| 2023/02/01 | Update file uploads/retrievals for Platforms                                                                          |
 | 2023/02/01 | Added the API reference for the Financial Actions API.                                                                |
 | 2023/01/26 | Add SEPA DD NAS Request and Response sources                                                                          |
 | 2023/01/24 | Update PaymentResponse `processing` object to add `partner_payment_id`, `partner_status`, `partner_transaction_id`,   |

--- a/nas_spec/components/schemas/HostedPayments/HostedPaymentsRequest.yaml
+++ b/nas_spec/components/schemas/HostedPayments/HostedPaymentsRequest.yaml
@@ -210,6 +210,7 @@ properties:
       - ar
       - da-DK
       - de-DE
+      - el
       - en-GB
       - es-ES
       - fi-FI
@@ -222,6 +223,7 @@ properties:
       - ms-MY
       - nb-NO
       - nl-NL
+      - pt-PT
       - sv-SE
       - th-TH
       - vi-VN

--- a/nas_spec/components/schemas/PaymentLinks/GetPaymentLinkResponse.yaml
+++ b/nas_spec/components/schemas/PaymentLinks/GetPaymentLinkResponse.yaml
@@ -155,6 +155,7 @@ properties:
       - ar
       - da-DK
       - de-DE
+      - el
       - en-GB
       - es-ES
       - fi-FI
@@ -167,6 +168,7 @@ properties:
       - ms-MY
       - nb-NO
       - nl-NL
+      - pt-PT
       - sv-SE
       - th-TH
       - vi-VN

--- a/nas_spec/components/schemas/PaymentLinks/PaymentLinksRequest.yaml
+++ b/nas_spec/components/schemas/PaymentLinks/PaymentLinksRequest.yaml
@@ -224,6 +224,7 @@ properties:
       - ar
       - da-DK
       - de-DE
+      - el
       - en-GB
       - es-ES
       - fi-FI
@@ -236,6 +237,7 @@ properties:
       - ms-MY
       - nb-NO
       - nl-NL
+      - pt-PT
       - sv-SE
       - th-TH
       - vi-VN


### PR DESCRIPTION
# Description of changes in PR

- Added new `pt-PT` and `el` locale options to both ABC and NAS references of Hosted Payments Page and Payment Links

## Checklist

- [x] Added a changelog entry to the `changelog.md` file in either `abc_spec` or `nas_spec`
- [x] Contacted the Tech Docs team about any corresponding guides that need to be updated for www.checkout.com/docs

**Contributing options**: Look at [our documentation](https://checkout.atlassian.net/wiki/spaces/PD/pages/2169506663/API+ref+publication+process) for options to contribute to the API reference.
