### PR TITLE
PTC-1663 | Added zip code format requirements for US Merchants

### DIFF
--- a/nas_spec/changelog.md
+++ b/nas_spec/changelog.md
@@ -2,7 +2,7 @@
 
 | Date       | Description of change                                                                                                 |
 |------------|-----------------------------------------------------------------------------------------------------------------------|
-| 2023/02/09 | Updated zip code format requirements for US merchants for Card Payouts                                                |
+| 2023/02/09 | Updated `zip` code format requirements for US merchants for Card Payouts                                                |
 | 2023/02/07 | Added Portuguese and Greek locale options to Hosted Payments Page and Payment Links                                   |
 | 2023/02/01 | Update file uploads/retrievals for Platforms                                                                          |
 | 2023/02/01 | Added the API reference for the Financial Actions API.                                                                |

--- a/nas_spec/changelog.md
+++ b/nas_spec/changelog.md
@@ -2,6 +2,7 @@
 
 | Date       | Description of change                                                                                                 |
 |------------|-----------------------------------------------------------------------------------------------------------------------|
+| 2023/02/09 | Updated zip code format requirements for US merchants for Card Payouts                                                |
 | 2023/02/07 | Added Portuguese and Greek locale options to Hosted Payments Page and Payment Links                                   |
 | 2023/02/01 | Update file uploads/retrievals for Platforms                                                                          |
 | 2023/02/01 | Added the API reference for the Financial Actions API.                                                                |

--- a/nas_spec/components/schemas/CardPayouts/CardPayoutRequest_DestinationAccountHolderTypes/01_CardPayoutRequest_DestinationTypeCardAccountHolderIndividual.yaml
+++ b/nas_spec/components/schemas/CardPayouts/CardPayoutRequest_DestinationAccountHolderTypes/01_CardPayoutRequest_DestinationTypeCardAccountHolderIndividual.yaml
@@ -68,7 +68,7 @@ properties:
         description: |
           The address ZIP (postal) code
 
-          ***Conditional*** - required for all Card Payouts requests by merchants incorporated in the US            
+          ***Conditional*** - required for all Card Payouts requests by merchants incorporated in the US; the format for US ZIPs must be nnnnn or nnnnn-nnnn       
         maxLength: 10
       country:
         type: string

--- a/nas_spec/components/schemas/CardPayouts/CardPayoutRequest_DestinationAccountHolderTypes/02_CardPayoutRequest_DestinationTypeCardAccountHolderCorporate.yaml
+++ b/nas_spec/components/schemas/CardPayouts/CardPayoutRequest_DestinationAccountHolderTypes/02_CardPayoutRequest_DestinationTypeCardAccountHolderCorporate.yaml
@@ -53,7 +53,7 @@ properties:
         description: |
           The address ZIP (postal) code
 
-          ***Conditional*** - required for all Card Payouts requests by merchants incorporated in the US 
+          ***Conditional*** - required for all Card Payouts requests by merchants incorporated in the US; the format for US ZIPs must be nnnnn or nnnnn-nnnn
         maxLength: 10
       country:
         type: string

--- a/nas_spec/components/schemas/CardPayouts/CardPayoutRequest_DestinationAccountHolderTypes/03_CardPayoutRequest_DestinationTypeCardAccountHolderGovernment.yaml
+++ b/nas_spec/components/schemas/CardPayouts/CardPayoutRequest_DestinationAccountHolderTypes/03_CardPayoutRequest_DestinationTypeCardAccountHolderGovernment.yaml
@@ -53,7 +53,7 @@ properties:
         description: |
           The address ZIP (postal) code
 
-          ***Conditional*** - required for all Card Payouts requests by merchants incorporated in the US 
+          ***Conditional*** - required for all Card Payouts requests by merchants incorporated in the US; the format for US ZIPs must be nnnnn or nnnnn-nnnn
         maxLength: 10
       country:
         type: string

--- a/nas_spec/components/schemas/CardPayouts/CardPayoutRequest_SenderAccountHolderTypes/01_CardPayoutRequest_SenderAccountHolderIndividual.yaml
+++ b/nas_spec/components/schemas/CardPayouts/CardPayoutRequest_SenderAccountHolderTypes/01_CardPayoutRequest_SenderAccountHolderIndividual.yaml
@@ -63,7 +63,7 @@ properties:
         description: |
           The ZIP (postal) code of the sender's residential address
 
-          ***Conditional*** - required for all Card Payouts requests by merchants incorporated in the US
+          ***Conditional*** - required for all Card Payouts requests by merchants incorporated in the US; the format for US ZIPs must be nnnnn or nnnnn-nnnn
         maxLength: 10
       country:
         type: string

--- a/nas_spec/components/schemas/CardPayouts/CardPayoutRequest_SenderAccountHolderTypes/02_CardPayoutRequest_SenderAccountHolderCorporate.yaml
+++ b/nas_spec/components/schemas/CardPayouts/CardPayoutRequest_SenderAccountHolderTypes/02_CardPayoutRequest_SenderAccountHolderCorporate.yaml
@@ -51,7 +51,7 @@ properties:
         description: |
           The ZIP (postal) code of the sender's registered address
 
-          ***Conditional*** - required for all Card Payouts requests by merchants incorporated in the US
+          ***Conditional*** - required for all Card Payouts requests by merchants incorporated in the US; the format for US ZIPs must be nnnnn or nnnnn-nnnn
         maxLength: 10
       country:
         type: string

--- a/nas_spec/components/schemas/CardPayouts/CardPayoutRequest_SenderAccountHolderTypes/03_CardPayoutRequest_SenderAccountHolderGovernment.yaml
+++ b/nas_spec/components/schemas/CardPayouts/CardPayoutRequest_SenderAccountHolderTypes/03_CardPayoutRequest_SenderAccountHolderGovernment.yaml
@@ -51,7 +51,7 @@ properties:
         description: |
           The ZIP (postal) code of the sender's registered address
 
-          ***Conditional*** - required for all Card Payouts requests by merchants incorporated in the US
+          ***Conditional*** - required for all Card Payouts requests by merchants incorporated in the US; the format for US ZIPs must be nnnnn or nnnnn-nnnn
         maxLength: 10
       country:
         type: string


### PR DESCRIPTION
# Description of changes in PR

[//]: # Added zip code requirements for US Merchants for Card Payout Requests

## Checklist

- [x] Added a changelog entry to the `changelog.md` file in either `abc_spec` or `nas_spec`
- [ ] Contacted the Tech Docs team about any corresponding guides that need to be updated for www.checkout.com/docs

**Contributing options**: Look at [our documentation](https://checkout.atlassian.net/wiki/spaces/PD/pages/2169506663/API+ref+publication+process) for options to contribute to the API reference.
