### PR TITLE
[MP-3707] Add if-match header to payment instrument patch request

### DIFF
--- a/nas_spec/changelog.md
+++ b/nas_spec/changelog.md
@@ -1,7 +1,8 @@
 # Changelog
 
 | Date       | Description of change                                                                                                   |
-|------------| ----------------------------------------------------------------------------------------------------------------------- |
+|------------|-------------------------------------------------------------------------------------------------------------------------|
+| 2023/04/03 | Added `if-match` header to `PlatformsPaymentInstrumentUpdate` for Integrated Platforms                                  |
 | 2023/04/02 | Added `card_token` object to `PlatformsPaymentInstrument` for Integrated Platforms                                      |
 | 2023/03/30 | Updated Bank Payouts docs hyperlink                                                                                     |
 | 2023/03/23 | Remove `marketplace` from Hosted Payments and Payment Links                                                             |

--- a/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentUpdate.yaml
+++ b/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentUpdate.yaml
@@ -14,7 +14,7 @@ properties:
     description: Specifies whether the payment instrument should be set as the default payout destination.
   headers:
     type: object
-    properties:
+    additionalProperties:
       type: string
       title: If-Match
       required: true

--- a/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentUpdate.yaml
+++ b/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentUpdate.yaml
@@ -14,9 +14,10 @@ properties:
     description: Specifies whether the payment instrument should be set as the default payout destination.
   headers:
     type: object
-    additionalProperties:
+    properties:
       type: string
       title: If-Match
+      required: true
       description: The instrument ETag value
     example:
       If-Match: 'Y3Y9MCZydj0w'

--- a/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentUpdate.yaml
+++ b/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentUpdate.yaml
@@ -12,3 +12,11 @@ properties:
     title: Default
     type: boolean
     description: Specifies whether the payment instrument should be set as the default payout destination.
+  headers:
+    type: object
+    additionalProperties:
+      type: string
+      title: If-Match
+      description: The instrument ETag value
+    example:
+      If-Match: 'Y3Y9MCZydj0w'

--- a/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentUpdate.yaml
+++ b/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentUpdate.yaml
@@ -13,11 +13,11 @@ properties:
     type: boolean
     description: Specifies whether the payment instrument should be set as the default payout destination.
   headers:
+    required:
+      - if-match
     type: object
-    additionalProperties:
-      type: string
-      title: If-Match
-      required: true
-      description: The instrument ETag value
-    example:
-      If-Match: 'Y3Y9MCZydj0w'
+    properties:
+      if-match:
+        type: string
+        description: The payment instrument ETag value.
+        example: 'Y3Y9MCZydj0w'

--- a/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentUpdate.yaml
+++ b/nas_spec/components/schemas/Platforms/PaymentInstruments/PlatformsPaymentInstrumentUpdate.yaml
@@ -19,5 +19,5 @@ properties:
     properties:
       if-match:
         type: string
-        description: The payment instrument ETag value.
+        description: The payment instrument ETag value
         example: 'Y3Y9MCZydj0w'

--- a/nas_spec/components/schemas/PreconditionRequiredError.yaml
+++ b/nas_spec/components/schemas/PreconditionRequiredError.yaml
@@ -1,0 +1,5 @@
+type: object
+properties:
+  status:
+    type: string
+    example: 428

--- a/nas_spec/paths/accounts@entities@{entityId}@payment-instruments@{id}.yaml
+++ b/nas_spec/paths/accounts@entities@{entityId}@payment-instruments@{id}.yaml
@@ -110,7 +110,7 @@ patch:
           schema:
             $ref: '#/components/schemas/ValidationError'
     '428': 
-      description: Precondition Required
+      description: Precondition required
       content:
         application/json:
           schema:

--- a/nas_spec/paths/accounts@entities@{entityId}@payment-instruments@{id}.yaml
+++ b/nas_spec/paths/accounts@entities@{entityId}@payment-instruments@{id}.yaml
@@ -109,5 +109,11 @@ patch:
         application/json:
           schema:
             $ref: '#/components/schemas/ValidationError'
+    '428': 
+      description: Precondition Required
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/PreconditionRequiredError'
   tags:
     - Payment instruments


### PR DESCRIPTION
# Description of changes in PR

Added `if-match` header to `PlatformsPaymentInstrumentUpdate` and documented the `428 Precondition Required` response returned if this header is not contained in the request.


## Checklist

- [x] Added a changelog entry to the `changelog.md` file in either `abc_spec` or `nas_spec`
- [x] Contacted the Tech Docs team about any corresponding guides that need to be updated for www.checkout.com/docs

**Contributing options**: Look at [our documentation](https://checkout.atlassian.net/wiki/spaces/PD/pages/2169506663/API+ref+publication+process) for options to contribute to the API reference.
