### PR TITLE
Replace duplicate content with link to auth failures doc

### DIFF
--- a/nas_spec/components/schemas/Standalone/ResponseStatusReason.yaml
+++ b/nas_spec/components/schemas/Standalone/ResponseStatusReason.yaml
@@ -2,33 +2,7 @@ description: >
   Only available as a result of a 3DS2 authentication. 
 
   The response from the DS or ACS which provides information on why the `response_code` field has the specified value.  <br/>
-  Only available when `response_code` is not `Y`.  <br/><br/>
-
-  • 01 = Card authentication failed <br/>
-  • 02 = Unknown Device <br/>
-  • 03 = Unsupported Device <br/>
-  • 04 = Exceeds authentication frequency limit <br/>
-  • 05 = Expired card <br/>
-  • 06 = Invalid card number <br/>
-  • 07 = Invalid transaction <br/>
-  • 08 = No Card record <br/>
-  • 09 = Security failure <br/>
-  • 10 = Stolen card <br/>
-  • 11 = Suspected fraud <br/>
-  • 12 = Transaction not permitted to cardholder <br/>
-  • 13 = Cardholder not enrolled in service <br/>
-  • 14 = Transaction timed out at the ACS <br/>
-  • 15 = Low confidence <br/>
-  • 16 = Medium confidence <br/>
-  • 17 = High confidence <br/>
-  • 18 = Very High confidence <br/>
-  • 19 = Exceeds ACS maximum challenges <br/>
-  • 20 = Non-Payment transaction not supported <br/>
-  • 21 = 3RI transaction not supported <br/>
-  • 22 = ACS technical issue <br/>
-  • 23 = Decoupled Authentication required by ACS but not requested by 3DS Requestor <br/>
-  • 24 = 3DS Requestor Decoupled Max Expiry Time exceeded <br/>
-  • 25 = Decoupled Authentication was provided insufficient time to authenticate cardholder. ACS will not make attempt <br/>
-  • 26 = Authentication attempted but not performed by the cardholder <br/>
+  Only available when `response_code` is not `Y`.  <br/>
+  Learn more about the reasons for <a href="https://www.checkout.com/docs/risk-management/3d-secure/sessions/understand-authentication-failures" target="_blank">authentication failures</a>.<br/><br/>
 example: '01'
 type: string


### PR DESCRIPTION
# [WRITING-1462](https://checkout.atlassian.net/browse/WRITING-1462)

Removes numerical value content from `response_status_reason` description within _Request a session_ response fields. This is because the values are already listed on the new docs site page, _Understand authentication failures_. For more context, see [JIRA issue](https://checkout.atlassian.net/browse/WRITING-1435).

Also adds link to new page.


