### PR TITLE
chore: PX-220 Remove Giropay payment method from NAS Hosted Payments and Payment Links

### DIFF
--- a/nas_spec/changelog.md
+++ b/nas_spec/changelog.md
@@ -1,8 +1,9 @@
 # Changelog
 
 | Date       | Description of change                                                                                                   |
-| ---------- | ----------------------------------------------------------------------------------------------------------------------- |
-| 2023/04/13 | Add `authentication_status_reason` to `3ds` object in the GET payment details response                                 |
+| ---------- |-------------------------------------------------------------------------------------------------------------------------|
+| 2023/04/21 | Remove `giropay` from Hosted Payments and Payment Links                                                                 |
+| 2023/04/13 | Add `authentication_status_reason` to `3ds` object in the GET payment details response                                  |
 | 2023/04/04 | Update conflict response for onboard sub entity operation to include ID                                                 |
 | 2023/04/03 | Updated `payment_ip` to support IPv6 addresses                                                                          |
 | 2023/03/28 | Increased NAS `recipient.account_number` max length from 10 to 34                                                       |

--- a/nas_spec/components/schemas/HostedPayments/HostedPaymentsRequest.yaml
+++ b/nas_spec/components/schemas/HostedPayments/HostedPaymentsRequest.yaml
@@ -141,7 +141,6 @@ properties:
       - sofort
       - ideal
       - knet
-      - giropay
       - bancontact
       - p24
       - eps

--- a/nas_spec/components/schemas/PaymentLinks/PaymentLinksRequest.yaml
+++ b/nas_spec/components/schemas/PaymentLinks/PaymentLinksRequest.yaml
@@ -146,7 +146,6 @@ properties:
       - sofort
       - ideal
       - knet
-      - giropay
       - bancontact
       - p24
       - eps


### PR DESCRIPTION
# Description of changes in PR

- Removed `giropay` payment method option from NAS Hosted Payments and Payment Links

## Checklist

- [x] Added a changelog entry to the `changelog.md` file in either `abc_spec` or `nas_spec`
- [x] Contacted the Tech Docs team about any corresponding guides that need to be updated for www.checkout.com/docs

**Contributing options**: Look at [our documentation](https://checkout.atlassian.net/wiki/spaces/PD/pages/2169506663/API+ref+publication+process) for options to contribute to the API reference.
